### PR TITLE
docs: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug Report
+description: Report a bug in HOP
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Windows
+        - Linux (Ubuntu/Debian)
+        - Linux (Fedora/RHEL)
+        - Linux (Arch/Manjaro)
+        - Linux (other)
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: OS Version
+      placeholder: "e.g. macOS 15.4, Windows 11 24H2, Ubuntu 24.04"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: package
+    attributes:
+      label: Install Package
+      options:
+        - DMG (macOS)
+        - Homebrew (macOS)
+        - MSI (Windows)
+        - AppImage (Linux)
+        - DEB (Linux)
+        - RPM (Linux)
+    validations:
+      required: true
+
+  - type: input
+    id: hop-version
+    attributes:
+      label: HOP Version
+      placeholder: "e.g. 0.1.8"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug clearly. Include screenshots if possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Step-by-step instructions to reproduce the issue.
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: |
+        Terminal error output, HWP sample file, IME name (for input issues), display setup (for rendering issues), etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem does this feature solve? Why is it needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature or change you'd like to see.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Editor / Rendering
+        - File handling (open/save/export)
+        - Fonts
+        - Printing
+        - Packaging / Installation
+        - UI / UX
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Screenshots, mockups, sample files, or links to related issues.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- Add structured YAML issue templates for **bug reports** and **feature requests**
- Bug report template captures OS, version, install package type, reproduction steps, and terminal output
- Feature request template captures motivation, proposed solution, and affected area
- Template fields are informed by the patterns in existing open issues (#12–#26)

## Test plan

- [ ] Verify templates render correctly on the "New Issue" page
- [ ] Confirm `bug` and `enhancement` labels are auto-applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)