### PR TITLE
test: add unit tests for UI dialog modules

### DIFF
--- a/apps/studio-host/src/ui/custom-select.test.ts
+++ b/apps/studio-host/src/ui/custom-select.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { enhanceCustomSelects, getCustomSelectRoot, syncCustomSelect } from './custom-select';
+
+class FakeElement {
+  tagName: string;
+  className = '';
+  textContent: string | null = '';
+  id = '';
+  type = '';
+  tabIndex = 0;
+  disabled = false;
+  value = '';
+  hidden = false;
+  dataset: Record<string, string> = {};
+  children: FakeElement[] = [];
+  parentNode: FakeElement | null = null;
+  private attrs = new Map<string, string>();
+  private listeners = new Map<string, Array<(event: unknown) => void>>();
+  private classes = new Set<string>();
+  private observer: { callback: MutationCallback } | null = null;
+
+  constructor(tagName = 'div') {
+    this.tagName = tagName.toUpperCase();
+  }
+
+  get classList() {
+    const self = this;
+    return {
+      add(cls: string) {
+        self.classes.add(cls);
+        self.className = Array.from(self.classes).join(' ');
+      },
+      remove(cls: string) {
+        self.classes.delete(cls);
+        self.className = Array.from(self.classes).join(' ');
+      },
+      contains(cls: string) {
+        return self.classes.has(cls) || self.className.split(/\s+/).includes(cls);
+      },
+      toggle(cls: string, force?: boolean) {
+        if (force === undefined) {
+          if (self.classes.has(cls)) self.classes.delete(cls);
+          else self.classes.add(cls);
+        } else if (force) {
+          self.classes.add(cls);
+        } else {
+          self.classes.delete(cls);
+        }
+        self.className = Array.from(self.classes).join(' ');
+      },
+    };
+  }
+
+  get selectedOptions(): FakeElement[] {
+    return this.children.filter((c) => (c as unknown as { selected: boolean }).selected);
+  }
+
+  get options(): FakeElement[] {
+    return this.children.filter((c) => c.tagName === 'OPTION');
+  }
+
+  get selectedIndex(): number {
+    const opts = this.options;
+    return opts.findIndex((o) => (o as unknown as { selected: boolean }).selected);
+  }
+
+  set selectedIndex(index: number) {
+    const opts = this.options;
+    opts.forEach((o, i) => {
+      (o as unknown as { selected: boolean }).selected = i === index;
+    });
+  }
+
+  setAttribute(name: string, value: string) { this.attrs.set(name, value); }
+  getAttribute(name: string) { return this.attrs.get(name) ?? null; }
+
+  addEventListener(type: string, listener: (event: unknown) => void, _capture?: boolean) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void, _capture?: boolean) {
+    const listeners = this.listeners.get(type) ?? [];
+    const idx = listeners.indexOf(listener);
+    if (idx >= 0) listeners.splice(idx, 1);
+  }
+
+  dispatchEvent(event: { type: string }) {
+    this.listeners.get(event.type)?.forEach((fn) => fn(event));
+  }
+
+  append(...children: FakeElement[]) {
+    for (const child of children) {
+      child.parentNode = this;
+      this.children.push(child);
+    }
+  }
+
+  appendChild(child: FakeElement) {
+    child.parentNode = this;
+    this.children.push(child);
+    return child;
+  }
+
+  before(newNode: FakeElement) {
+    if (this.parentNode) {
+      const idx = this.parentNode.children.indexOf(this);
+      if (idx >= 0) {
+        newNode.parentNode = this.parentNode;
+        this.parentNode.children.splice(idx, 0, newNode);
+      }
+    }
+  }
+
+  contains(node: unknown): boolean {
+    if (node === this) return true;
+    return this.children.some((c) => c.contains(node));
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    for (const child of this.allDescendants()) {
+      if (matchesSelector(child, selector)) return child;
+    }
+    return null;
+  }
+
+  querySelectorAll<T = FakeElement>(selector: string): T[] {
+    return this.allDescendants().filter((c) => matchesSelector(c, selector)) as T[];
+  }
+
+  focus() {}
+
+  private allDescendants(): FakeElement[] {
+    const result: FakeElement[] = [];
+    for (const child of this.children) {
+      result.push(child);
+      result.push(...child.allDescendants());
+    }
+    return result;
+  }
+}
+
+function matchesSelector(el: FakeElement, selector: string): boolean {
+  const parts = selector.split(',').map((s) => s.trim());
+  return parts.some((part) => {
+    const dotIdx = part.indexOf('.');
+    if (dotIdx > 0) {
+      const tag = part.slice(0, dotIdx).toUpperCase();
+      const cls = part.slice(dotIdx + 1);
+      return el.tagName === tag && el.classList.contains(cls);
+    }
+    if (part.startsWith('.')) return el.classList.contains(part.slice(1));
+    if (part.startsWith('#')) return el.id === part.slice(1);
+    return el.tagName === part.toUpperCase();
+  });
+}
+
+function createFakeSelect(className: string, options: string[] = []): FakeElement {
+  const select = new FakeElement('select');
+  select.className = className;
+  (select as unknown as { multiple: boolean }).multiple = false;
+  (select as unknown as { size: number }).size = 1;
+  for (const text of options) {
+    const opt = new FakeElement('option');
+    opt.tagName = 'OPTION';
+    opt.textContent = text;
+    opt.value = text;
+    (opt as unknown as { selected: boolean }).selected = false;
+    select.appendChild(opt);
+  }
+  if (options.length > 0) {
+    (select.children[0] as unknown as { selected: boolean }).selected = true;
+  }
+  return select;
+}
+
+class FakeDocument {
+  body = new FakeElement('body');
+  head = new FakeElement('head');
+  private listeners = new Map<string, Array<(event: unknown) => void>>();
+
+  createElement(tag: string): FakeElement {
+    return new FakeElement(tag);
+  }
+
+  addEventListener(type: string, listener: (event: unknown) => void, _capture?: boolean) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener() {}
+
+  querySelectorAll<T = FakeElement>(selector: string): T[] {
+    return this.body.querySelectorAll<T>(selector);
+  }
+}
+
+class FakeMutationObserver {
+  observe() {}
+  disconnect() {}
+}
+
+describe('custom-select', () => {
+  let fakeDocument: FakeDocument;
+
+  beforeEach(() => {
+    fakeDocument = new FakeDocument();
+    (globalThis as Record<string, unknown>).document = fakeDocument;
+    (globalThis as Record<string, unknown>).MutationObserver = FakeMutationObserver;
+    (globalThis as Record<string, unknown>).HTMLOptGroupElement = class {};
+    (globalThis as Record<string, unknown>).HTMLOptionElement = class {};
+    (globalThis as Record<string, unknown>).Event = class { type: string; bubbles: boolean; constructor(type: string, opts?: { bubbles?: boolean }) { this.type = type; this.bubbles = opts?.bubbles ?? false; } };
+  });
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).document;
+    delete (globalThis as Record<string, unknown>).MutationObserver;
+    delete (globalThis as Record<string, unknown>).HTMLOptGroupElement;
+    delete (globalThis as Record<string, unknown>).HTMLOptionElement;
+    delete (globalThis as Record<string, unknown>).Event;
+  });
+
+  it('getCustomSelectRoot returns null for an unenhanced select', () => {
+    const select = createFakeSelect('sb-combo');
+    expect(getCustomSelectRoot(select as unknown as HTMLSelectElement)).toBeNull();
+  });
+
+  it('syncCustomSelect is a no-op for an unenhanced select', () => {
+    const select = createFakeSelect('sb-combo');
+    expect(() => syncCustomSelect(select as unknown as HTMLSelectElement)).not.toThrow();
+  });
+
+  it('skips selects that do not match supported class selectors', () => {
+    const container = new FakeElement('div');
+    const select = createFakeSelect('unsupported-class', ['A', 'B']);
+    container.appendChild(select);
+
+    enhanceCustomSelects(container as unknown as ParentNode);
+
+    expect(getCustomSelectRoot(select as unknown as HTMLSelectElement)).toBeNull();
+  });
+
+  it('skips select elements with multiple attribute', () => {
+    const container = new FakeElement('div');
+    const select = createFakeSelect('sb-combo', ['A', 'B']);
+    (select as unknown as { multiple: boolean }).multiple = true;
+    container.appendChild(select);
+
+    enhanceCustomSelects(container as unknown as ParentNode);
+
+    expect(getCustomSelectRoot(select as unknown as HTMLSelectElement)).toBeNull();
+  });
+
+  it('skips select elements with size > 1', () => {
+    const container = new FakeElement('div');
+    const select = createFakeSelect('sb-combo', ['A', 'B']);
+    (select as unknown as { size: number }).size = 5;
+    container.appendChild(select);
+
+    enhanceCustomSelects(container as unknown as ParentNode);
+
+    expect(getCustomSelectRoot(select as unknown as HTMLSelectElement)).toBeNull();
+  });
+
+  it('skips select elements with data-native-select="true"', () => {
+    const container = new FakeElement('div');
+    const select = createFakeSelect('sb-combo', ['A', 'B']);
+    select.dataset.nativeSelect = 'true';
+    container.appendChild(select);
+
+    enhanceCustomSelects(container as unknown as ParentNode);
+
+    expect(getCustomSelectRoot(select as unknown as HTMLSelectElement)).toBeNull();
+  });
+
+  it('enhances a matching select and exposes root via getCustomSelectRoot', () => {
+    const container = new FakeElement('div');
+    const select = createFakeSelect('sb-combo', ['Option A', 'Option B']);
+    container.appendChild(select);
+
+    enhanceCustomSelects(container as unknown as ParentNode);
+
+    const root = getCustomSelectRoot(select as unknown as HTMLSelectElement);
+    expect(root).not.toBeNull();
+  });
+
+  it('does not enhance the same select twice', () => {
+    const container = new FakeElement('div');
+    const select = createFakeSelect('dialog-select', ['A']);
+    container.appendChild(select);
+
+    enhanceCustomSelects(container as unknown as ParentNode);
+    const root1 = getCustomSelectRoot(select as unknown as HTMLSelectElement);
+
+    enhanceCustomSelects(container as unknown as ParentNode);
+    const root2 = getCustomSelectRoot(select as unknown as HTMLSelectElement);
+
+    expect(root1).toBe(root2);
+  });
+
+  it('syncCustomSelect updates display after enhancement', () => {
+    const container = new FakeElement('div');
+    const select = createFakeSelect('sb-combo', ['First', 'Second']);
+    container.appendChild(select);
+
+    enhanceCustomSelects(container as unknown as ParentNode);
+
+    expect(() => syncCustomSelect(select as unknown as HTMLSelectElement)).not.toThrow();
+  });
+});

--- a/apps/studio-host/src/ui/custom-select.test.ts
+++ b/apps/studio-host/src/ui/custom-select.test.ts
@@ -3,7 +3,7 @@ import { enhanceCustomSelects, getCustomSelectRoot, syncCustomSelect } from './c
 
 class FakeElement {
   tagName: string;
-  className = '';
+  private _className = '';
   textContent: string | null = '';
   id = '';
   type = '';
@@ -23,19 +23,28 @@ class FakeElement {
     this.tagName = tagName.toUpperCase();
   }
 
+  get className(): string {
+    return this._className;
+  }
+
+  set className(value: string) {
+    this._className = value;
+    this.classes = new Set(value.split(/\s+/).filter(Boolean));
+  }
+
   get classList() {
     const self = this;
     return {
       add(cls: string) {
         self.classes.add(cls);
-        self.className = Array.from(self.classes).join(' ');
+        self._className = Array.from(self.classes).join(' ');
       },
       remove(cls: string) {
         self.classes.delete(cls);
-        self.className = Array.from(self.classes).join(' ');
+        self._className = Array.from(self.classes).join(' ');
       },
       contains(cls: string) {
-        return self.classes.has(cls) || self.className.split(/\s+/).includes(cls);
+        return self.classes.has(cls);
       },
       toggle(cls: string, force?: boolean) {
         if (force === undefined) {
@@ -46,7 +55,7 @@ class FakeElement {
         } else {
           self.classes.delete(cls);
         }
-        self.className = Array.from(self.classes).join(' ');
+        self._className = Array.from(self.classes).join(' ');
       },
     };
   }
@@ -141,6 +150,22 @@ class FakeElement {
   }
 }
 
+class FakeOption extends FakeElement {
+  selected = false;
+
+  constructor() {
+    super('option');
+  }
+}
+
+class FakeOptGroup extends FakeElement {
+  label = '';
+
+  constructor() {
+    super('optgroup');
+  }
+}
+
 function matchesSelector(el: FakeElement, selector: string): boolean {
   const parts = selector.split(',').map((s) => s.trim());
   return parts.some((part) => {
@@ -162,15 +187,14 @@ function createFakeSelect(className: string, options: string[] = []): FakeElemen
   (select as unknown as { multiple: boolean }).multiple = false;
   (select as unknown as { size: number }).size = 1;
   for (const text of options) {
-    const opt = new FakeElement('option');
-    opt.tagName = 'OPTION';
+    const opt = new FakeOption();
     opt.textContent = text;
     opt.value = text;
-    (opt as unknown as { selected: boolean }).selected = false;
     select.appendChild(opt);
   }
   if (options.length > 0) {
-    (select.children[0] as unknown as { selected: boolean }).selected = true;
+    (select.children[0] as FakeOption).selected = true;
+    select.value = options[0];
   }
   return select;
 }
@@ -209,8 +233,8 @@ describe('custom-select', () => {
     fakeDocument = new FakeDocument();
     (globalThis as Record<string, unknown>).document = fakeDocument;
     (globalThis as Record<string, unknown>).MutationObserver = FakeMutationObserver;
-    (globalThis as Record<string, unknown>).HTMLOptGroupElement = class {};
-    (globalThis as Record<string, unknown>).HTMLOptionElement = class {};
+    (globalThis as Record<string, unknown>).HTMLOptGroupElement = FakeOptGroup;
+    (globalThis as Record<string, unknown>).HTMLOptionElement = FakeOption;
     (globalThis as Record<string, unknown>).Event = class { type: string; bubbles: boolean; constructor(type: string, opts?: { bubbles?: boolean }) { this.type = type; this.bubbles = opts?.bubbles ?? false; } };
   });
 
@@ -275,7 +299,7 @@ describe('custom-select', () => {
     expect(getCustomSelectRoot(select as unknown as HTMLSelectElement)).toBeNull();
   });
 
-  it('enhances a matching select and exposes root via getCustomSelectRoot', () => {
+  it('enhances a matching select and creates option rows with correct display', () => {
     const container = new FakeElement('div');
     const select = createFakeSelect('sb-combo', ['Option A', 'Option B']);
     container.appendChild(select);
@@ -284,29 +308,59 @@ describe('custom-select', () => {
 
     const root = getCustomSelectRoot(select as unknown as HTMLSelectElement);
     expect(root).not.toBeNull();
+
+    const rootEl = root as unknown as FakeElement;
+    const menuRows = rootEl.querySelectorAll('.custom-select-option');
+    expect(menuRows.length).toBe(2);
+    expect((menuRows[0] as FakeElement).textContent).toBe('Option A');
+    expect((menuRows[1] as FakeElement).textContent).toBe('Option B');
+
+    const valueSpan = rootEl.querySelector('.custom-select-value');
+    expect(valueSpan).not.toBeNull();
+    expect((valueSpan as FakeElement).textContent).toBe('Option A');
+
+    expect((menuRows[0] as FakeElement).classList.contains('selected')).toBe(true);
+    expect((menuRows[1] as FakeElement).classList.contains('selected')).toBe(false);
   });
 
-  it('does not enhance the same select twice', () => {
+  it('does not enhance the same select twice (idempotent DOM)', () => {
     const container = new FakeElement('div');
-    const select = createFakeSelect('dialog-select', ['A']);
+    const select = createFakeSelect('dialog-select', ['A', 'B']);
     container.appendChild(select);
 
     enhanceCustomSelects(container as unknown as ParentNode);
     const root1 = getCustomSelectRoot(select as unknown as HTMLSelectElement);
+    const rowsBefore = (root1 as unknown as FakeElement).querySelectorAll('.custom-select-option');
 
     enhanceCustomSelects(container as unknown as ParentNode);
     const root2 = getCustomSelectRoot(select as unknown as HTMLSelectElement);
+    const rowsAfter = (root2 as unknown as FakeElement).querySelectorAll('.custom-select-option');
 
     expect(root1).toBe(root2);
+    expect(rowsAfter.length).toBe(rowsBefore.length);
+    expect(rowsAfter.length).toBe(2);
   });
 
-  it('syncCustomSelect updates display after enhancement', () => {
+  it('syncCustomSelect updates display text and selected class', () => {
     const container = new FakeElement('div');
     const select = createFakeSelect('sb-combo', ['First', 'Second']);
     container.appendChild(select);
 
     enhanceCustomSelects(container as unknown as ParentNode);
 
-    expect(() => syncCustomSelect(select as unknown as HTMLSelectElement)).not.toThrow();
+    (select.children[0] as FakeOption).selected = false;
+    (select.children[1] as FakeOption).selected = true;
+    select.value = 'Second';
+    syncCustomSelect(select as unknown as HTMLSelectElement);
+
+    const root = getCustomSelectRoot(select as unknown as HTMLSelectElement);
+    const rootEl = root as unknown as FakeElement;
+
+    const valueSpan = rootEl.querySelector('.custom-select-value');
+    expect((valueSpan as FakeElement).textContent).toBe('Second');
+
+    const menuRows = rootEl.querySelectorAll('.custom-select-option');
+    expect((menuRows[0] as FakeElement).classList.contains('selected')).toBe(false);
+    expect((menuRows[1] as FakeElement).classList.contains('selected')).toBe(true);
   });
 });

--- a/apps/studio-host/src/ui/dialog.test.ts
+++ b/apps/studio-host/src/ui/dialog.test.ts
@@ -1,0 +1,302 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./custom-select', () => ({
+  enhanceCustomSelects: vi.fn(),
+}));
+
+import { ModalDialog } from './dialog';
+
+class FakeElement {
+  className = '';
+  textContent: string | null = '';
+  id = '';
+  disabled = false;
+  isConnected = true;
+  children: FakeElement[] = [];
+  style: Record<string, string> = {};
+  private attrs = new Map<string, string>();
+  private listeners = new Map<string, Array<(event: unknown) => void>>();
+  private classes = new Set<string>();
+
+  get classList() {
+    const self = this;
+    return {
+      add(cls: string) { self.classes.add(cls); },
+      remove(cls: string) { self.classes.delete(cls); },
+      contains(cls: string) {
+        return self.classes.has(cls) || self.className.split(/\s+/).includes(cls);
+      },
+    };
+  }
+
+  click(): void {
+    this.listeners.get('click')?.forEach((fn) => fn({}));
+  }
+
+  setAttribute(name: string, value: string) { this.attrs.set(name, value); }
+  getAttribute(name: string) { return this.attrs.get(name) ?? null; }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  addEventListener(type: string, listener: (event: unknown) => void, capture?: boolean) {
+    const key = capture ? `${type}:capture` : type;
+    const list = this.listeners.get(key) ?? [];
+    list.push(listener);
+    this.listeners.set(key, list);
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void, capture?: boolean) {
+    const key = capture ? `${type}:capture` : type;
+    const list = this.listeners.get(key) ?? [];
+    const idx = list.indexOf(listener);
+    if (idx >= 0) list.splice(idx, 1);
+  }
+
+  dispatchCapture(type: string, event: unknown) {
+    this.listeners.get(`${type}:capture`)?.forEach((fn) => fn(event));
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    for (const child of this.allDescendants()) {
+      if (selector.startsWith('.')) {
+        const cls = selector.slice(1);
+        if (child.classList.contains(cls) || child.className.split(/\s+/).includes(cls)) {
+          return child;
+        }
+      }
+    }
+    return null;
+  }
+
+  remove(): void {
+    this.isConnected = false;
+  }
+
+  focus(): void {}
+
+  private allDescendants(): FakeElement[] {
+    const result: FakeElement[] = [];
+    for (const child of this.children) {
+      result.push(child);
+      result.push(...child.allDescendants());
+    }
+    return result;
+  }
+}
+
+class FakeDocument {
+  body = new FakeElement();
+  private listeners = new Map<string, Array<(event: unknown) => void>>();
+
+  createElement(_tag: string): FakeElement {
+    return new FakeElement();
+  }
+
+  addEventListener(type: string, listener: (event: unknown) => void, capture?: boolean) {
+    const key = capture ? `${type}:capture` : type;
+    const list = this.listeners.get(key) ?? [];
+    list.push(listener);
+    this.listeners.set(key, list);
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void, capture?: boolean) {
+    const key = capture ? `${type}:capture` : type;
+    const list = this.listeners.get(key) ?? [];
+    const idx = list.indexOf(listener);
+    if (idx >= 0) list.splice(idx, 1);
+  }
+
+  dispatchCapture(type: string, event: unknown) {
+    this.listeners.get(`${type}:capture`)?.forEach((fn) => fn(event));
+  }
+}
+
+class TestDialog extends ModalDialog {
+  confirmResult: void | boolean | Promise<void | boolean> = undefined;
+  bodyElement = new FakeElement();
+
+  constructor(title = 'Test', width = 400) {
+    super(title, width);
+  }
+
+  protected createBody(): HTMLElement {
+    this.bodyElement.classList.add('test-body');
+    return this.bodyElement as unknown as HTMLElement;
+  }
+
+  protected onConfirm(): void | boolean | Promise<void | boolean> {
+    return this.confirmResult;
+  }
+}
+
+class FakeHTMLInputElement {}
+class FakeHTMLTextAreaElement {}
+
+describe('ModalDialog', () => {
+  let fakeDocument: FakeDocument;
+
+  beforeEach(() => {
+    fakeDocument = new FakeDocument();
+    (globalThis as Record<string, unknown>).document = fakeDocument;
+    (globalThis as Record<string, unknown>).HTMLInputElement = FakeHTMLInputElement;
+    (globalThis as Record<string, unknown>).HTMLTextAreaElement = FakeHTMLTextAreaElement;
+  });
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).document;
+    delete (globalThis as Record<string, unknown>).HTMLInputElement;
+    delete (globalThis as Record<string, unknown>).HTMLTextAreaElement;
+  });
+
+  it('appends overlay to document body on show', () => {
+    const dialog = new TestDialog('My Title', 300);
+    dialog.show();
+
+    expect(fakeDocument.body.children.length).toBe(1);
+    const overlay = fakeDocument.body.children[0];
+    expect(overlay.className).toBe('modal-overlay');
+  });
+
+  it('creates dialog with correct title', () => {
+    const dialog = new TestDialog('문서 설정', 500);
+    dialog.show();
+
+    const overlay = fakeDocument.body.children[0];
+    const wrap = overlay.children[0];
+    expect(wrap.className).toBe('dialog-wrap');
+    expect(wrap.style.width).toBe('500px');
+
+    const titleBar = wrap.children[0];
+    expect(titleBar.className).toBe('dialog-title');
+    expect(titleBar.textContent).toBe('문서 설정');
+  });
+
+  it('creates close button, body, and footer', () => {
+    const dialog = new TestDialog();
+    dialog.show();
+
+    const overlay = fakeDocument.body.children[0];
+    const wrap = overlay.children[0];
+
+    expect(wrap.children.length).toBe(3);
+
+    const titleBar = wrap.children[0];
+    const closeBtn = titleBar.children[0];
+    expect(closeBtn.className).toBe('dialog-close');
+    expect(closeBtn.textContent).toBe('×');
+
+    const body = wrap.children[1];
+    expect(body.classList.contains('dialog-body')).toBe(true);
+
+    const footer = wrap.children[2];
+    expect(footer.className).toBe('dialog-footer');
+    expect(footer.children.length).toBe(2);
+
+    const confirmBtn = footer.children[0];
+    expect(confirmBtn.textContent).toBe('확인');
+    expect(confirmBtn.classList.contains('dialog-btn-primary')).toBe(true);
+
+    const cancelBtn = footer.children[1];
+    expect(cancelBtn.textContent).toBe('취소');
+  });
+
+  it('removes overlay on hide', () => {
+    const dialog = new TestDialog();
+    dialog.show();
+
+    const overlay = fakeDocument.body.children[0];
+    expect(overlay.isConnected).toBe(true);
+
+    dialog.hide();
+    expect(overlay.isConnected).toBe(false);
+  });
+
+  it('Escape key triggers hide', () => {
+    const dialog = new TestDialog();
+    dialog.show();
+
+    const overlay = fakeDocument.body.children[0];
+    const event = {
+      key: 'Escape',
+      target: null,
+      stopPropagation: vi.fn(),
+      preventDefault: vi.fn(),
+    };
+
+    fakeDocument.dispatchCapture('keydown', event);
+
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(overlay.isConnected).toBe(false);
+  });
+
+  it('Enter key on non-input triggers confirm', () => {
+    const onConfirm = vi.fn();
+    const dialog = new TestDialog();
+    dialog.confirmResult = onConfirm() as undefined;
+    dialog.show();
+
+    const event = {
+      key: 'Enter',
+      target: { tagName: 'DIV' },
+      stopPropagation: vi.fn(),
+      preventDefault: vi.fn(),
+    };
+
+    fakeDocument.dispatchCapture('keydown', event);
+
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('does not build DOM twice on repeated show calls', () => {
+    const dialog = new TestDialog();
+    dialog.show();
+    dialog.hide();
+    dialog.show();
+
+    expect(fakeDocument.body.children.length).toBe(2);
+
+    const overlay1 = fakeDocument.body.children[0];
+    const overlay2 = fakeDocument.body.children[1];
+    expect(overlay1).toBe(overlay2);
+  });
+
+  it('stops propagation for all keyboard events while open', () => {
+    const dialog = new TestDialog();
+    dialog.show();
+
+    const event = {
+      key: 'a',
+      target: { tagName: 'DIV' },
+      stopPropagation: vi.fn(),
+      preventDefault: vi.fn(),
+    };
+
+    fakeDocument.dispatchCapture('keydown', event);
+
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('allows typing in input elements', () => {
+    const dialog = new TestDialog();
+    dialog.show();
+
+    const fakeInput = new FakeHTMLInputElement();
+    const event = {
+      key: 'a',
+      target: fakeInput,
+      stopPropagation: vi.fn(),
+      preventDefault: vi.fn(),
+    };
+
+    fakeDocument.dispatchCapture('keydown', event);
+
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/apps/studio-host/src/ui/dialog.test.ts
+++ b/apps/studio-host/src/ui/dialog.test.ts
@@ -14,6 +14,7 @@ class FakeElement {
   isConnected = true;
   children: FakeElement[] = [];
   style: Record<string, string> = {};
+  parentNode: FakeElement | null = null;
   private attrs = new Map<string, string>();
   private listeners = new Map<string, Array<(event: unknown) => void>>();
   private classes = new Set<string>();
@@ -37,6 +38,11 @@ class FakeElement {
   getAttribute(name: string) { return this.attrs.get(name) ?? null; }
 
   appendChild(child: FakeElement): FakeElement {
+    if (child.parentNode) {
+      const idx = child.parentNode.children.indexOf(child);
+      if (idx >= 0) child.parentNode.children.splice(idx, 1);
+    }
+    child.parentNode = this;
     this.children.push(child);
     return child;
   }
@@ -73,6 +79,11 @@ class FakeElement {
 
   remove(): void {
     this.isConnected = false;
+    if (this.parentNode) {
+      const idx = this.parentNode.children.indexOf(this);
+      if (idx >= 0) this.parentNode.children.splice(idx, 1);
+      this.parentNode = null;
+    }
   }
 
   focus(): void {}
@@ -171,7 +182,7 @@ describe('ModalDialog', () => {
 
     const titleBar = wrap.children[0];
     expect(titleBar.className).toBe('dialog-title');
-    expect(titleBar.textContent).toBe('문서 설정');
+    expect(titleBar.textContent).toContain('문서 설정');
   });
 
   it('creates close button, body, and footer', () => {
@@ -233,12 +244,11 @@ describe('ModalDialog', () => {
     expect(overlay.isConnected).toBe(false);
   });
 
-  it('Enter key on non-input triggers confirm', () => {
-    const onConfirm = vi.fn();
+  it('Enter key on non-input triggers confirm and closes dialog', async () => {
     const dialog = new TestDialog();
-    dialog.confirmResult = onConfirm() as undefined;
     dialog.show();
 
+    const overlay = fakeDocument.body.children[0];
     const event = {
       key: 'Enter',
       target: { tagName: 'DIV' },
@@ -250,19 +260,20 @@ describe('ModalDialog', () => {
 
     expect(event.stopPropagation).toHaveBeenCalled();
     expect(event.preventDefault).toHaveBeenCalled();
+    await Promise.resolve();
+    expect(overlay.isConnected).toBe(false);
   });
 
   it('does not build DOM twice on repeated show calls', () => {
     const dialog = new TestDialog();
     dialog.show();
+    const overlay = fakeDocument.body.children[0];
+
     dialog.hide();
     dialog.show();
 
-    expect(fakeDocument.body.children.length).toBe(2);
-
-    const overlay1 = fakeDocument.body.children[0];
-    const overlay2 = fakeDocument.body.children[1];
-    expect(overlay1).toBe(overlay2);
+    expect(fakeDocument.body.children.length).toBe(1);
+    expect(fakeDocument.body.children[0]).toBe(overlay);
   });
 
   it('stops propagation for all keyboard events while open', () => {

--- a/apps/studio-host/src/ui/print-dialog.test.ts
+++ b/apps/studio-host/src/ui/print-dialog.test.ts
@@ -86,8 +86,8 @@ describe('openPrintDialog', () => {
     (globalThis as Record<string, unknown>).document = fakeDocument;
     (globalThis as Record<string, unknown>).window = {
       print: printMock,
-      setTimeout: globalThis.setTimeout,
-      clearTimeout: globalThis.clearTimeout,
+      setTimeout: vi.fn(() => 0),
+      clearTimeout: vi.fn(),
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
     };

--- a/apps/studio-host/src/ui/print-dialog.test.ts
+++ b/apps/studio-host/src/ui/print-dialog.test.ts
@@ -165,5 +165,16 @@ describe('openPrintDialog', () => {
     await openPrintDialog(doc, { print: printMock });
 
     expect(doc.renderPageSvg).toHaveBeenCalledTimes(1);
+
+    const printRoot = fakeDocument.body.children.find((c) => c.id === 'hop-print-root');
+    expect(printRoot).toBeDefined();
+    const pageDiv = printRoot!.children.find((c) => c.className === 'hop-print-page');
+    expect(pageDiv).toBeDefined();
+    expect(pageDiv!.children.length).toBe(0);
+
+    expect(printMock).toHaveBeenCalled();
+
+    const win = (globalThis as Record<string, unknown>).window as Record<string, ReturnType<typeof vi.fn>>;
+    expect(win.addEventListener).toHaveBeenCalledWith('afterprint', expect.any(Function), { once: true });
   });
 });

--- a/apps/studio-host/src/ui/print-dialog.test.ts
+++ b/apps/studio-host/src/ui/print-dialog.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { openPrintDialog } from './print-dialog';
+
+class FakeElement {
+  id = '';
+  className = '';
+  textContent: string | null = '';
+  hidden = false;
+  children: FakeElement[] = [];
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  tagName: string;
+  private attrs = new Map<string, string>();
+
+  constructor(tagName = 'div') {
+    this.tagName = tagName.toUpperCase();
+  }
+
+  setAttribute(name: string, value: string) { this.attrs.set(name, value); }
+  getAttribute(name: string) { return this.attrs.get(name) ?? null; }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  remove(): void {}
+
+  querySelector(_selector: string): FakeElement | null {
+    return null;
+  }
+
+  querySelectorAll(_selector: string): FakeElement[] {
+    return [];
+  }
+}
+
+class FakeDocument {
+  head = new FakeElement('head');
+  body = new FakeElement('body');
+
+  createElement(tag: string): FakeElement {
+    return new FakeElement(tag);
+  }
+
+  getElementById(id: string): FakeElement | null {
+    return findById(this.head, id) ?? findById(this.body, id) ?? null;
+  }
+
+  importNode(node: unknown, _deep: boolean): unknown {
+    return node;
+  }
+}
+
+function findById(root: FakeElement, id: string): FakeElement | null {
+  if (root.id === id) return root;
+  for (const child of root.children) {
+    const found = findById(child, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+function makeFakeDOMParser(hasParseerror = false) {
+  return class {
+    parseFromString() {
+      return {
+        querySelector: (sel: string) => (hasParseerror && sel === 'parsererror' ? {} : null),
+        documentElement: {
+          tagName: hasParseerror ? 'html' : 'svg',
+          querySelectorAll: () => [],
+          attributes: [],
+        },
+      };
+    }
+  };
+}
+
+describe('openPrintDialog', () => {
+  let fakeDocument: FakeDocument;
+  let printMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fakeDocument = new FakeDocument();
+    printMock = vi.fn();
+    (globalThis as Record<string, unknown>).document = fakeDocument;
+    (globalThis as Record<string, unknown>).window = {
+      print: printMock,
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    (globalThis as Record<string, unknown>).DOMParser = makeFakeDOMParser();
+    (globalThis as Record<string, unknown>).requestAnimationFrame = (cb: () => void) => {
+      cb();
+      return 0;
+    };
+  });
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).document;
+    delete (globalThis as Record<string, unknown>).window;
+    delete (globalThis as Record<string, unknown>).DOMParser;
+    delete (globalThis as Record<string, unknown>).requestAnimationFrame;
+  });
+
+  it('returns immediately when page count is 0', async () => {
+    const doc = {
+      fileName: 'empty.hwp',
+      pageCount: 0,
+      getPageInfo: vi.fn(),
+      renderPageSvg: vi.fn(),
+    };
+
+    await openPrintDialog(doc);
+
+    expect(doc.getPageInfo).not.toHaveBeenCalled();
+    expect(doc.renderPageSvg).not.toHaveBeenCalled();
+    expect(printMock).not.toHaveBeenCalled();
+  });
+
+  it('calls onStatus with progress messages during preparation', async () => {
+    const onStatus = vi.fn();
+    const doc = {
+      fileName: 'test.hwp',
+      pageCount: 2,
+      getPageInfo: vi.fn(() => ({ width: 595, height: 842 })),
+      renderPageSvg: vi.fn(() => '<svg></svg>'),
+    };
+
+    await openPrintDialog(doc, { onStatus, print: printMock });
+
+    expect(onStatus).toHaveBeenCalledWith('인쇄 준비 중... (1/2)');
+    expect(onStatus).toHaveBeenCalledWith('인쇄 준비 중... (2/2)');
+    expect(onStatus).toHaveBeenCalledWith('인쇄 대화상자를 여는 중...');
+  });
+
+  it('renders all pages via renderPageSvg', async () => {
+    const doc = {
+      fileName: 'test.hwp',
+      pageCount: 3,
+      getPageInfo: vi.fn(() => ({ width: 595, height: 842 })),
+      renderPageSvg: vi.fn(() => '<svg></svg>'),
+    };
+
+    await openPrintDialog(doc, { print: printMock });
+
+    expect(doc.renderPageSvg).toHaveBeenCalledTimes(3);
+    expect(doc.renderPageSvg).toHaveBeenCalledWith(0);
+    expect(doc.renderPageSvg).toHaveBeenCalledWith(1);
+    expect(doc.renderPageSvg).toHaveBeenCalledWith(2);
+  });
+
+  it('rejects malformed SVG gracefully', async () => {
+    (globalThis as Record<string, unknown>).DOMParser = makeFakeDOMParser(true);
+
+    const doc = {
+      fileName: 'bad.hwp',
+      pageCount: 1,
+      getPageInfo: vi.fn(() => ({ width: 595, height: 842 })),
+      renderPageSvg: vi.fn(() => '<not-valid-svg>'),
+    };
+
+    await openPrintDialog(doc, { print: printMock });
+
+    expect(doc.renderPageSvg).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Add unit tests for three previously untested UI modules
- **custom-select.ts** (9 tests): enhancement skip conditions (multiple, size>1, data-native-select), getCustomSelectRoot/syncCustomSelect API, idempotent re-enhancement
- **dialog.ts** (9 tests): ModalDialog DOM structure, show/hide lifecycle, Escape key close, Enter key confirm, keyboard capture allowing input in editable elements
- **print-dialog.ts** (4 tests): zero-page early exit, onStatus progress callbacks, per-page SVG rendering, malformed SVG graceful handling

All tests follow the existing FakeElement/FakeDocument pattern used in `update-notice.test.ts` — no jsdom dependency needed.

## Test plan

- [x] `pnpm run test:studio` — all 105 tests pass (23 files)
- [x] No changes to production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)