### PR TITLE
docs: add keyboard shortcuts reference

### DIFF
--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -1,0 +1,109 @@
+# Keyboard Shortcuts
+
+Shortcuts use **Cmd** on macOS and **Ctrl** on Windows/Linux.
+
+## File
+
+| Shortcut | Action |
+|---|---|
+| Alt+N | New Document |
+| Cmd/Ctrl+Shift+N | New Window |
+| Cmd/Ctrl+O | Open |
+| Cmd/Ctrl+S | Save |
+| Cmd/Ctrl+Shift+S | Save As |
+| Cmd/Ctrl+E | Export PDF |
+| Cmd/Ctrl+P | Print |
+| F7 | Page Setup |
+| Cmd/Ctrl+Q | Quit HOP |
+
+## Edit
+
+| Shortcut | Action |
+|---|---|
+| Cmd/Ctrl+Z | Undo |
+| Cmd/Ctrl+Shift+Z | Redo |
+| Cmd/Ctrl+Y | Redo |
+| Cmd/Ctrl+A | Select All |
+| Cmd/Ctrl+F | Find |
+| Cmd/Ctrl+F2 | Find and Replace |
+| Cmd/Ctrl+L | Find Again |
+| Alt+G | Go To |
+
+## Format
+
+| Shortcut | Action |
+|---|---|
+| Cmd/Ctrl+B | Bold |
+| Cmd/Ctrl+I | Italic |
+| Cmd/Ctrl+U | Underline |
+| Alt+L | Character Shape |
+| Alt+T | Paragraph Shape |
+| F6 | Style Dialog |
+
+### Font Size
+
+| Shortcut | Action |
+|---|---|
+| Cmd/Ctrl+] | Increase Font Size |
+| Cmd/Ctrl+[ | Decrease Font Size |
+| Alt+Shift+E | Increase Font Size |
+| Alt+Shift+R | Decrease Font Size |
+
+### Line Spacing
+
+| Shortcut | Action |
+|---|---|
+| Alt+Shift+Z | Increase Line Spacing |
+| Alt+Shift+A | Decrease Line Spacing |
+
+### Paragraph Alignment
+
+| Shortcut | Action |
+|---|---|
+| Cmd/Ctrl+Shift+L | Align Left |
+| Cmd/Ctrl+Shift+M | Justify |
+| Alt+Shift+H | Align Right |
+| Alt+Shift+C | Align Center |
+| Alt+Shift+D | Distribute |
+
+## Table
+
+| Shortcut | Action |
+|---|---|
+| Cmd/Ctrl+Alt+T | Select Cells |
+| Alt+Insert | Insert Column Left |
+| Alt+Delete | Delete Column |
+
+## View
+
+| Shortcut | Action |
+|---|---|
+| Cmd/Ctrl+= | Zoom In |
+| Cmd/Ctrl+- | Zoom Out |
+| Cmd/Ctrl+0 | Actual Size (100%) |
+
+## Page
+
+| Shortcut | Action |
+|---|---|
+| Cmd/Ctrl+Enter | Page Break |
+| Cmd/Ctrl+Shift+Enter | Column Break |
+
+## Insert
+
+| Shortcut | Action |
+|---|---|
+| Alt+F10 | Insert Symbols |
+
+## Notes
+
+Some shortcuts are remapped from the original Hancom 한글 defaults to avoid
+browser/webview conflicts:
+
+- **Align Right**: Ctrl+Shift+R (browser hard-refresh) → Alt+Shift+H
+- **Align Center**: Ctrl+Shift+C (browser dev tools) → Alt+Shift+C
+- **Distribute**: Ctrl+Shift+T (browser tab restore) → Alt+Shift+D
+
+Korean IME key equivalents (ㅜ, ㄹ, ㅅ, ㅎ, ㅁ, ㅋ, ㄷ, ㄱ) are also
+registered for Alt-based shortcuts so they work regardless of the active
+input method.

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -1,11 +1,13 @@
 # Keyboard Shortcuts
 
-Shortcuts use **Cmd** on macOS and **Ctrl** on Windows/Linux.
+Shortcuts use **Cmd** on macOS and **Ctrl** on Windows/Linux. For shortcuts
+that use **Alt**, macOS users should use **Option (⌥)**.
 
 ## File
 
 | Shortcut | Action |
 |---|---|
+| Cmd/Ctrl+N | New Document |
 | Alt+N | New Document |
 | Cmd/Ctrl+Shift+N | New Window |
 | Cmd/Ctrl+O | Open |
@@ -23,6 +25,9 @@ Shortcuts use **Cmd** on macOS and **Ctrl** on Windows/Linux.
 | Cmd/Ctrl+Z | Undo |
 | Cmd/Ctrl+Shift+Z | Redo |
 | Cmd/Ctrl+Y | Redo |
+| Cmd/Ctrl+X | Cut |
+| Cmd/Ctrl+C | Copy |
+| Cmd/Ctrl+V | Paste |
 | Cmd/Ctrl+A | Select All |
 | Cmd/Ctrl+F | Find |
 | Cmd/Ctrl+F2 | Find and Replace |

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 ```text
 docs/
   DEVELOPMENT.md             로컬 개발 환경과 주요 명령
+  KEYBOARD_SHORTCUTS.md      키보드 단축키 레퍼런스
   specs/
     initial/
       SPEC.md                초기 제품 및 public beta 스펙


### PR DESCRIPTION
## Summary

- Add `docs/KEYBOARD_SHORTCUTS.md` with a complete reference of all keyboard shortcuts
- Compiled from `menu.rs` (native menu accelerators) and `shortcut-map.ts` (upstream + HOP overrides)
- Organized by category: File, Edit, Format, Table, View, Page, Insert
- Documents the Hancom → HOP remappings (Ctrl+Shift+R/C/T → Alt+Shift+H/C/D) that avoid browser/webview conflicts
- Notes Korean IME key equivalents

## Test plan

- [x] Cross-referenced every shortcut against source code
- [x] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)