### PR TITLE
에디터의 선택/클릭 감도와 복사·붙여넣기 동작을 개선했습니다.

### DIFF
--- a/apps/studio-host/hop-overrides.ts
+++ b/apps/studio-host/hop-overrides.ts
@@ -12,6 +12,7 @@ const overrideIds = [
   'core/platform',
   'core/tauri-bridge',
   'command/shortcut-map',
+  'command/commands/edit',
   'command/commands/format',
   'command/commands/table',
   'command/commands/file',

--- a/apps/studio-host/index.html
+++ b/apps/studio-host/index.html
@@ -380,9 +380,9 @@
     <!-- 아이콘 툴바 -->
     <div id="icon-toolbar">
       <div class="tb-group">
-        <button class="tb-btn" title="오려두기 (Ctrl+X)"><span class="tb-sprite icon-cut"></span><span class="tb-label">오려<br/>두기</span></button>
-        <button class="tb-btn" title="복사하기 (Ctrl+C)"><span class="tb-sprite icon-copy"></span><span class="tb-label">복사<br/>하기</span></button>
-        <button class="tb-btn tb-paste" title="붙이기 (Ctrl+V)">
+        <button class="tb-btn" data-cmd="edit:cut" title="오려두기 (Ctrl+X)"><span class="tb-sprite icon-cut"></span><span class="tb-label">오려<br/>두기</span></button>
+        <button class="tb-btn" data-cmd="edit:copy" title="복사하기 (Ctrl+C)"><span class="tb-sprite icon-copy"></span><span class="tb-label">복사<br/>하기</span></button>
+        <button class="tb-btn tb-paste" data-cmd="edit:paste" title="붙이기 (Ctrl+V)">
           <span class="tb-sprite icon-paste"></span><span class="tb-label">붙이기</span>
         </button>
         <button class="tb-btn" title="모양 복사"><span class="tb-sprite icon-format-copy"></span><span class="tb-label">모양<br/>복사</span></button>

--- a/apps/studio-host/src/command/commands/edit.test.ts
+++ b/apps/studio-host/src/command/commands/edit.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@upstream/command/commands/edit', () => ({
+  editCommands: [
+    { id: 'edit:copy', label: '복사하기', execute: vi.fn() },
+    { id: 'edit:paste', label: '붙이기', execute: vi.fn() },
+    { id: 'edit:find', label: '찾기', execute: vi.fn() },
+  ],
+}));
+
+import { editCommands } from './edit';
+
+describe('edit command overrides', () => {
+  it('routes paste through the input handler instead of document.execCommand', () => {
+    const performPaste = vi.fn();
+    const command = editCommands.find((item) => item.id === 'edit:paste');
+
+    command?.execute({
+      getInputHandler: () => ({ performPaste }),
+    } as never);
+
+    expect(performPaste).toHaveBeenCalled();
+  });
+
+  it('keeps unrelated upstream edit commands available', () => {
+    expect(editCommands.some((item) => item.id === 'edit:find')).toBe(true);
+  });
+});

--- a/apps/studio-host/src/command/commands/edit.ts
+++ b/apps/studio-host/src/command/commands/edit.ts
@@ -1,0 +1,45 @@
+import { editCommands as upstreamEditCommands } from '@upstream/command/commands/edit';
+import type { CommandDef } from '@upstream/command/types';
+
+type ClipboardCapableInputHandler = {
+  performCopy?: () => void;
+  performCut?: () => void;
+  performPaste?: () => void | Promise<void>;
+};
+
+const hopEditCommandById = new Map<string, CommandDef>([
+  ['edit:cut', {
+    id: 'edit:cut',
+    label: '오려 두기',
+    icon: 'icon-cut',
+    shortcutLabel: 'Ctrl+X',
+    canExecute: (ctx) => ctx.hasDocument && (ctx.hasSelection || ctx.inPictureObjectSelection || ctx.inTableObjectSelection),
+    execute(services) {
+      (services.getInputHandler() as ClipboardCapableInputHandler | null)?.performCut?.();
+    },
+  }],
+  ['edit:copy', {
+    id: 'edit:copy',
+    label: '복사하기',
+    icon: 'icon-copy',
+    shortcutLabel: 'Ctrl+C',
+    canExecute: (ctx) => ctx.hasDocument && (ctx.hasSelection || ctx.inPictureObjectSelection || ctx.inTableObjectSelection),
+    execute(services) {
+      (services.getInputHandler() as ClipboardCapableInputHandler | null)?.performCopy?.();
+    },
+  }],
+  ['edit:paste', {
+    id: 'edit:paste',
+    label: '붙이기',
+    icon: 'icon-paste',
+    shortcutLabel: 'Ctrl+V',
+    canExecute: (ctx) => ctx.hasDocument,
+    execute(services) {
+      void (services.getInputHandler() as ClipboardCapableInputHandler | null)?.performPaste?.();
+    },
+  }],
+]);
+
+export const editCommands: CommandDef[] = upstreamEditCommands.map((command) =>
+  hopEditCommandById.get(command.id) ?? command,
+);

--- a/apps/studio-host/src/engine/input-handler-mouse.test.ts
+++ b/apps/studio-host/src/engine/input-handler-mouse.test.ts
@@ -1,5 +1,23 @@
 import { describe, expect, it, vi } from 'vitest';
-import { tryHandleCellSelectionClick } from './input-handler-mouse';
+import { hitTestNearPagePoint, selectParagraphAtPointer, tryHandleCellSelectionClick } from './input-handler-mouse';
+
+describe('hitTestNearPagePoint', () => {
+  it('falls back to nearby points when the exact click misses text', () => {
+    const hitTest = vi.fn()
+      .mockImplementationOnce(() => {
+        throw new Error('miss');
+      })
+      .mockReturnValueOnce({ paragraphIndex: 0xFFFFFF00 })
+      .mockReturnValueOnce({ sectionIndex: 0, paragraphIndex: 2, charOffset: 5 });
+
+    const hit = hitTestNearPagePoint({ hitTest }, 0, 100, 200);
+
+    expect(hit).toEqual({ sectionIndex: 0, paragraphIndex: 2, charOffset: 5 });
+    expect(hitTest).toHaveBeenNthCalledWith(1, 0, 100, 200);
+    expect(hitTest).toHaveBeenNthCalledWith(2, 0, 96, 200);
+    expect(hitTest).toHaveBeenNthCalledWith(3, 0, 104, 200);
+  });
+});
 
 describe('tryHandleCellSelectionClick', () => {
   it('promotes phase 1 selection into a mouse-driven range selection on plain click', () => {
@@ -70,5 +88,53 @@ describe('tryHandleCellSelectionClick', () => {
     expect(handled).toBe(true);
     expect(shiftSelectCell).toHaveBeenCalledWith(1, 1);
     expect(ctrlToggleCell).not.toHaveBeenCalled();
+  });
+});
+
+describe('selectParagraphAtPointer', () => {
+  it('selects the whole paragraph under a double-click', () => {
+    const clearSelection = vi.fn();
+    const moveTo = vi.fn();
+    const setAnchor = vi.fn();
+    const updateCaret = vi.fn();
+    const focus = vi.fn();
+
+    const handled = selectParagraphAtPointer.call(
+      {
+        viewportManager: { getZoom: () => 2 },
+        container: {
+          querySelector: () => ({
+            clientWidth: 500,
+            getBoundingClientRect: () => ({ left: 10, top: 20 }),
+          }),
+        },
+        virtualScroll: {
+          getPageAtY: () => 0,
+          getPageOffset: () => 100,
+          getPageLeft: () => null,
+          getPageWidth: () => 400,
+        },
+        wasm: {
+          hitTest: vi.fn(() => ({ sectionIndex: 0, paragraphIndex: 3, charOffset: 4 })),
+          getParagraphLength: vi.fn(() => 12),
+        },
+        cursor: { clearSelection, moveTo, setAnchor },
+        updateCaret,
+        textarea: { focus },
+      },
+      {
+        clientX: 210,
+        clientY: 140,
+        target: { closest: () => null },
+      } as unknown as MouseEvent,
+    );
+
+    expect(handled).toBe(true);
+    expect(clearSelection).toHaveBeenCalled();
+    expect(moveTo).toHaveBeenNthCalledWith(1, { sectionIndex: 0, paragraphIndex: 3, charOffset: 0 });
+    expect(setAnchor).toHaveBeenCalled();
+    expect(moveTo).toHaveBeenNthCalledWith(2, { sectionIndex: 0, paragraphIndex: 3, charOffset: 12 });
+    expect(updateCaret).toHaveBeenCalled();
+    expect(focus).toHaveBeenCalled();
   });
 });

--- a/apps/studio-host/src/engine/input-handler-mouse.ts
+++ b/apps/studio-host/src/engine/input-handler-mouse.ts
@@ -5,6 +5,36 @@ import type { ContextMenuItem } from '@/ui/context-menu';
 import * as _connector from '@upstream/engine/input-handler-connector';
 import { resolveVirtualScrollPageLeft } from '../view/page-left';
 
+const INVALID_PARAGRAPH_INDEX = 0xFFFFFF00;
+const HIT_TEST_FALLBACK_OFFSETS = [
+  [0, 0],
+  [-4, 0], [4, 0], [0, -4], [0, 4],
+  [-8, 0], [8, 0], [0, -8], [0, 8],
+  [-8, -8], [8, -8], [-8, 8], [8, 8],
+  [-14, 0], [14, 0], [0, -14], [0, 14],
+  [-18, -6], [18, -6], [-18, 6], [18, 6],
+  [-24, 0], [24, 0], [0, -24], [0, 24],
+] as const;
+
+export function hitTestNearPagePoint(
+  wasm: { hitTest: (pageIdx: number, pageX: number, pageY: number) => any },
+  pageIdx: number,
+  pageX: number,
+  pageY: number,
+): any | null {
+  for (const [dx, dy] of HIT_TEST_FALLBACK_OFFSETS) {
+    try {
+      const hit = wasm.hitTest(pageIdx, pageX + dx, pageY + dy);
+      if (hit && hit.paragraphIndex < INVALID_PARAGRAPH_INDEX) {
+        return hit;
+      }
+    } catch {
+      // Try the next nearby point.
+    }
+  }
+  return null;
+}
+
 export function tryHandleCellSelectionClick(this: any, e: MouseEvent): boolean {
   if (!this.cursor.isInCellSelectionMode() || e.button === 2) {
     return false;
@@ -591,10 +621,14 @@ export function onClick(this: any, e: MouseEvent): void {
   }
 
   try {
-    const hit = this.wasm.hitTest(pageIdx, pageX, pageY);
+    const hit = hitTestNearPagePoint(this.wasm, pageIdx, pageX, pageY);
+    if (!hit) {
+      this.textarea.focus();
+      return;
+    }
 
     // 머리말/꼬리말 마커 para_index(usize::MAX - hf_idx) 감지 → 무시
-    if (hit.paragraphIndex >= 0xFFFFFF00) {
+    if (hit.paragraphIndex >= INVALID_PARAGRAPH_INDEX) {
       this.textarea.focus();
       return;
     }
@@ -841,6 +875,78 @@ export function onDblClick(this: any, e: MouseEvent): void {
       return;
     }
   }
+
+  if (selectParagraphAtPointer.call(this, e)) {
+    e.preventDefault();
+  }
+}
+
+export function selectParagraphAtPointer(this: any, e: MouseEvent): boolean {
+  const target = e.target as HTMLElement;
+  if (target.closest('#menu-bar') || target.closest('#icon-toolbar') || target.closest('#style-bar')) return false;
+
+  const zoom = this.viewportManager.getZoom();
+  const scrollContent = this.container.querySelector('#scroll-content');
+  if (!scrollContent) return false;
+
+  const contentRect = scrollContent.getBoundingClientRect();
+  const contentX = e.clientX - contentRect.left;
+  const contentY = e.clientY - contentRect.top;
+  const pageIdx = this.virtualScroll.getPageAtY(contentY);
+  if (pageIdx < 0) return false;
+
+  const pageOffset = this.virtualScroll.getPageOffset(pageIdx);
+  const pageLeft = resolveVirtualScrollPageLeft(
+    this.virtualScroll,
+    pageIdx,
+    (scrollContent as HTMLElement).clientWidth,
+  );
+  const pageX = (contentX - pageLeft) / zoom;
+  const pageY = (contentY - pageOffset) / zoom;
+
+  try {
+    const hit = hitTestNearPagePoint(this.wasm, pageIdx, pageX, pageY);
+    if (!hit || hit.paragraphIndex >= INVALID_PARAGRAPH_INDEX) return false;
+
+    let start;
+    let end;
+    if (hit.parentParaIndex !== undefined && hit.cellIndex !== undefined && hit.cellParaIndex !== undefined) {
+      const length = this.wasm.getCellParagraphLength(
+        hit.sectionIndex,
+        hit.parentParaIndex,
+        hit.controlIndex!,
+        hit.cellIndex,
+        hit.cellParaIndex,
+      );
+      start = { ...hit, charOffset: 0 };
+      end = { ...hit, charOffset: length };
+    } else {
+      const length = this.wasm.getParagraphLength(hit.sectionIndex, hit.paragraphIndex);
+      start = {
+        sectionIndex: hit.sectionIndex,
+        paragraphIndex: hit.paragraphIndex,
+        charOffset: 0,
+      };
+      end = {
+        sectionIndex: hit.sectionIndex,
+        paragraphIndex: hit.paragraphIndex,
+        charOffset: length,
+      };
+    }
+
+    this.cursor.clearSelection();
+    this.cursor.moveTo(start);
+    this.cursor.setAnchor();
+    this.cursor.moveTo(end);
+    this.active = true;
+    this.isDragging = false;
+    this.updateCaret();
+    this.textarea.focus();
+    return true;
+  } catch (err) {
+    console.warn('[InputHandler] 문단 선택 실패:', err);
+    return false;
+  }
 }
 
 export function onContextMenu(this: any, e: MouseEvent): void {
@@ -883,7 +989,7 @@ export function onContextMenu(this: any, e: MouseEvent): void {
 
   let inTable = false;
   try {
-    const hit = this.wasm.hitTest(pageIdx, pageX, pageY);
+    const hit = hitTestNearPagePoint(this.wasm, pageIdx, pageX, pageY);
     inTable = hit.parentParaIndex !== undefined && !hit.isTextBox;
   } catch { /* hitTest 실패 시 표 밖으로 처리 */ }
 
@@ -1092,7 +1198,7 @@ export function onMouseMove(this: any, e: MouseEvent): void {
       this.dragRafId = 0;
       if (!this.isDragging) return;
       const hit = this.hitTestFromEvent(e);
-      if (hit && hit.paragraphIndex < 0xFFFFFF00) {
+      if (hit && hit.paragraphIndex < INVALID_PARAGRAPH_INDEX) {
         this.cursor.moveTo(hit);
         this.updateCaret();
       }

--- a/apps/studio-host/src/engine/input-handler.ts
+++ b/apps/studio-host/src/engine/input-handler.ts
@@ -28,6 +28,25 @@ import * as _picture from '@upstream/engine/input-handler-picture';
 import { resolvePageLeft, resolveVirtualScrollPageLeft } from '../view/page-left';
 import { appendSvgElement, appendSvgLine, createOverlayLabel, createSvgRoot } from './svg-dom';
 
+type ClipboardDataLike = {
+  defaultPrevented: boolean;
+  items: DataTransferItemList;
+  getData: (type: string) => string;
+  setData: (type: string, value: string) => void;
+};
+
+function createClipboardDataLike(): ClipboardDataLike {
+  const values = new Map<string, string>();
+  return {
+    defaultPrevented: false,
+    items: [] as unknown as DataTransferItemList,
+    getData: (type: string) => values.get(type) ?? '',
+    setData: (type: string, value: string) => {
+      values.set(type, value);
+    },
+  };
+}
+
 /** 클릭 커서 배치 + 키보드 입력을 처리한다 */
 export class InputHandler {
   private cursor: CursorState;
@@ -936,11 +955,7 @@ export class InputHandler {
     );
     const pageX = (contentX - pageLeft) / zoom;
     const pageY = (contentY - pageOffset) / zoom;
-    try {
-      return this.wasm.hitTest(pageIdx, pageX, pageY);
-    } catch {
-      return null;
-    }
+    return _mouse.hitTestNearPagePoint(this.wasm, pageIdx, pageX, pageY);
   }
 
   /** 클릭 좌표가 표 외곽 경계선 위인지 판별한다 (페이지 좌표 기준) */
@@ -1134,6 +1149,69 @@ export class InputHandler {
   /** 붙여넣기 이벤트 처리 */
   private onPaste(e: ClipboardEvent): void {
     _keyboard.onPaste.call(this, e);
+  }
+
+  private createClipboardEvent(clipboardData: ClipboardDataLike): ClipboardEvent {
+    return {
+      clipboardData,
+      preventDefault: () => {
+        clipboardData.defaultPrevented = true;
+      },
+    } as unknown as ClipboardEvent;
+  }
+
+  private async writeSyntheticClipboard(clipboardData: ClipboardDataLike): Promise<void> {
+    const plain = clipboardData.getData('text/plain');
+    const html = clipboardData.getData('text/html');
+    if (!plain && !html) return;
+
+    try {
+      if (html && typeof ClipboardItem !== 'undefined' && navigator.clipboard?.write) {
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            'text/plain': new Blob([plain], { type: 'text/plain' }),
+            'text/html': new Blob([html], { type: 'text/html' }),
+          }),
+        ]);
+        return;
+      }
+      if (plain && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(plain);
+      }
+    } catch {
+      this.focusTextarea();
+      document.execCommand('copy');
+    }
+  }
+
+  private async readSyntheticClipboard(): Promise<ClipboardDataLike> {
+    const clipboardData = createClipboardDataLike();
+
+    try {
+      if (navigator.clipboard?.read) {
+        const items = await navigator.clipboard.read();
+        for (const item of items) {
+          if (item.types.includes('text/html')) {
+            clipboardData.setData('text/html', await (await item.getType('text/html')).text());
+          }
+          if (item.types.includes('text/plain')) {
+            clipboardData.setData('text/plain', await (await item.getType('text/plain')).text());
+          }
+        }
+        return clipboardData;
+      }
+    } catch {
+      // readText fallback below.
+    }
+
+    try {
+      if (navigator.clipboard?.readText) {
+        clipboardData.setData('text/plain', await navigator.clipboard.readText());
+      }
+    } catch {
+      // Empty clipboardData lets the upstream path still use the internal WASM clipboard.
+    }
+    return clipboardData;
   }
 
   // ─── 서식 적용 ─────────────────────────────────────────
@@ -2195,9 +2273,9 @@ export class InputHandler {
       }
       return;
     }
-    // 텍스트 선택 → textarea 포커스 후 execCommand
-    this.focusTextarea();
-    document.execCommand('copy');
+    const clipboardData = createClipboardDataLike();
+    _keyboard.onCopy.call(this, this.createClipboardEvent(clipboardData));
+    void this.writeSyntheticClipboard(clipboardData);
   }
 
   /** 잘라내기 (커맨드 시스템용 — 컨텍스트 메뉴/도구 상자에서 호출) */
@@ -2236,9 +2314,15 @@ export class InputHandler {
       }
       return;
     }
-    // 텍스트 선택 → textarea 포커스 후 execCommand
-    this.focusTextarea();
-    document.execCommand('cut');
+    const clipboardData = createClipboardDataLike();
+    _keyboard.onCut.call(this, this.createClipboardEvent(clipboardData));
+    void this.writeSyntheticClipboard(clipboardData);
+  }
+
+  /** 붙여넣기 (커맨드 시스템용 — 메뉴/도구 상자에서 호출) */
+  async performPaste(): Promise<void> {
+    const clipboardData = await this.readSyntheticClipboard();
+    _keyboard.onPaste.call(this, this.createClipboardEvent(clipboardData));
   }
 
   /** 전체 선택 (커맨드 시스템용) */


### PR DESCRIPTION
에디터의 선택/클릭 감도와 복사·붙여넣기 동작을 개선했습니다.

문단 더블클릭 시 문단 전체가 선택되도록 수정
텍스트나 표 셀을 정확히 클릭하지 않아도 가까운 위치로 커서가 잡히도록 hit-test 보정
드래그 선택에도 동일한 근처 hit-test 보정 적용
맥에서 복사가 불가능 하던 오류를 수정했습니다.
맥에서는 붙여넣기 하려면 단축키를 누르고 또 버튼을 눌러야 하는 불편함을 줄이기 위하여  툴바의 오려두기/복사/붙여넣기 버튼을 실제 편집 커맨드에 연결
붙여넣기 버튼이 document.execCommand('paste')에만 의존하지 않도록 시스템 클립보드 기반 처리 추가
복사/잘라내기 시 선택 내용을 시스템 클립보드에 기록하도록 보강
관련 단위 테스트 추가
