### PR TITLE
rhwp v0.7.9 기준으로 동기화하고 문서 검증/lineseg 자동 보정 기능 복원함

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3671,7 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "rhwp"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -4321,7 +4321,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5043,7 +5043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/apps/studio-host/package.json
+++ b/apps/studio-host/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "dependencies": {
-    "@rhwp/core": "0.7.8",
+    "@rhwp/core": "0.7.9",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-fs": "2.5.0"

--- a/apps/studio-host/src/main.ts
+++ b/apps/studio-host/src/main.ts
@@ -26,6 +26,7 @@ import { pageCommands } from '@/command/commands/page';
 import { toolCommands } from '@/command/commands/tool';
 import { ContextMenu } from '@/ui/context-menu';
 import { CommandPalette } from '@/ui/command-palette';
+import { showValidationModalIfNeeded } from '@/ui/validation-modal';
 import { CellSelectionRenderer } from '@/engine/cell-selection-renderer';
 import { TableObjectRenderer } from '@/engine/table-object-renderer';
 import { TableResizeRenderer } from '@/engine/table-resize-renderer';
@@ -520,6 +521,23 @@ async function initializeDocument(docInfo: DocumentInfo, displayName: string): P
     toolbar?.setEnabled(true);
     toolbar?.initStyleDropdown();
     inputHandler?.activateWithCaretPosition();
+
+    try {
+      const report = wasm.getValidationWarnings();
+      console.log(`[validation] ${report.count} warnings`, report.summary);
+      if (report.count > 0) {
+        const choice = await showValidationModalIfNeeded(report);
+        console.log(`[validation] user choice: ${choice}`);
+        if (choice === 'auto-fix') {
+          const reflowedCount = wasm.reflowLinesegs();
+          console.log(`[validation] reflowed ${reflowedCount} paragraphs`);
+          canvasView?.loadDocument();
+          msg.textContent = `${displayName} (비표준 lineseg ${reflowedCount}건 자동 보정됨)`;
+        }
+      }
+    } catch (error) {
+      console.warn('[validation] 감지/보정 실패 (치명적이지 않음):', error);
+    }
   } catch (error) {
     console.error('[initDoc] 오류:', error);
     if (window.innerWidth < 768) alert(`초기화 오류: ${error}`);

--- a/docs/architecture/UPSTREAM.md
+++ b/docs/architecture/UPSTREAM.md
@@ -4,7 +4,7 @@ HOP는 `edwardkim/rhwp`를 읽기 전용 upstream 의존성으로 사용한다.
 
 * upstream URL: `https://github.com/edwardkim/rhwp.git`
 * submodule 경로: `third_party/rhwp`
-* 기준 고정 커밋: `42cf91b6ba7b50fa1c853c01158a52ef68b45442` (`v0.7.8`)
+* 기준 고정 커밋: `0fb3e6758b8ad11d2f3c3849c83b914684e83863` (`v0.7.9`)
 * HOP 작업 브랜치: `main`
 
 ## 소유권 규칙
@@ -47,12 +47,13 @@ UPSTREAM_BRANCH=devel RUN_CHECKS=1 scripts/update-upstream.sh
 release tag나 특정 commit으로 pinning하려면 `UPSTREAM_REF`를 사용한다.
 
 ```sh
-UPSTREAM_REF=v0.7.8 RUN_CHECKS=1 scripts/update-upstream.sh
+UPSTREAM_REF=v0.7.9 RUN_CHECKS=1 scripts/update-upstream.sh
 ```
 
 업데이트 후에는 다음을 확인한다.
 
 * submodule pointer diff
+* `apps/studio-host`의 `@rhwp/core` 버전과 `apps/desktop/src-tauri/Cargo.lock`의 `rhwp` 버전 정합
 * `apps/studio-host` override의 타입/import 깨짐
 * `apps/desktop/src-tauri`의 native Rust API 깨짐
 * HOP가 별도로 보정하던 UI/파일/인쇄/창 이벤트 동작

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:desktop": "pnpm --filter hop-desktop build",
     "tauri": "pnpm --filter hop-desktop tauri",
     "test": "pnpm run test:upstream && pnpm run test:studio && pnpm run test:desktop",
-    "test:upstream": "node --test tests/update-upstream.test.mjs",
+    "test:upstream": "node --test tests/update-upstream.test.mjs tests/rhwp-baseline.test.mjs",
     "test:studio": "pnpm --filter @golbin/hop-studio-host test",
     "test:desktop": "cd apps/desktop/src-tauri && cargo test",
     "clippy:desktop": "cd apps/desktop/src-tauri && cargo clippy -- -D warnings"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
   apps/studio-host:
     dependencies:
       '@rhwp/core':
-        specifier: 0.7.8
-        version: 0.7.8
+        specifier: 0.7.9
+        version: 0.7.9
       '@tauri-apps/api':
         specifier: ^2.10.1
         version: 2.10.1
@@ -62,8 +62,8 @@ packages:
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
-  '@rhwp/core@0.7.8':
-    resolution: {integrity: sha512-WfgmH9ItxSn68YFf0CofrRYdA4rk0HbN7bV2kFc/hdfCk19MdlVWyzQ69modmiCvb/AFTPNUcYg5B3iNSP4e0Q==}
+  '@rhwp/core@0.7.9':
+    resolution: {integrity: sha512-J7sKdTNECC2Sl4WErLDONynSF3UAlAzWaJ67T7xFjBxL1eS2yooT3CB8yNfrDOTlUZVtakZSd7LsYzinL/bj1A==}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
@@ -589,7 +589,7 @@ snapshots:
 
   '@oxc-project/types@0.124.0': {}
 
-  '@rhwp/core@0.7.8': {}
+  '@rhwp/core@0.7.9': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true

--- a/tests/rhwp-baseline.test.mjs
+++ b/tests/rhwp-baseline.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const expectedRhwpVersion = '0.7.9';
+const expectedRhwpCommit = '0fb3e6758b8ad11d2f3c3849c83b914684e83863';
+
+test('HOP keeps the rhwp renderer baseline aligned across submodule, WASM package, and native lockfile', async () => {
+  const studioPackage = JSON.parse(
+    await readFile(join(repoRoot, 'apps/studio-host/package.json'), 'utf8'),
+  );
+  assert.equal(studioPackage.dependencies['@rhwp/core'], expectedRhwpVersion);
+
+  const pnpmLock = await readFile(join(repoRoot, 'pnpm-lock.yaml'), 'utf8');
+  assert.match(pnpmLock, new RegExp(`@rhwp/core@${escapeRegExp(expectedRhwpVersion)}`));
+
+  const cargoLock = await readFile(join(repoRoot, 'apps/desktop/src-tauri/Cargo.lock'), 'utf8');
+  assert.match(
+    cargoLock,
+    new RegExp(`name = "rhwp"\\nversion = "${escapeRegExp(expectedRhwpVersion)}"`),
+  );
+
+  const upstreamDoc = await readFile(join(repoRoot, 'docs/architecture/UPSTREAM.md'), 'utf8');
+  assert.match(upstreamDoc, new RegExp(escapeRegExp(expectedRhwpCommit)));
+  assert.match(upstreamDoc, new RegExp(escapeRegExp(`v${expectedRhwpVersion}`)));
+
+  const submoduleStatus = git(['submodule', 'status', 'third_party/rhwp']).stdout.trim();
+  assert.match(submoduleStatus, new RegExp(`^[ +-]?${expectedRhwpCommit} third_party/rhwp\\b`));
+});
+
+test('HOP preserves upstream lineseg validation and auto-reflow on document load', async () => {
+  const mainSource = await readFile(join(repoRoot, 'apps/studio-host/src/main.ts'), 'utf8');
+
+  assert.match(mainSource, /showValidationModalIfNeeded/);
+  assert.match(mainSource, /wasm\.getValidationWarnings\(\)/);
+  assert.match(mainSource, /wasm\.reflowLinesegs\(\)/);
+  assert.match(mainSource, /canvasView\?\.loadDocument\(\)/);
+});
+
+function git(args) {
+  const result = spawnSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_TERMINAL_PROMPT: '0',
+    },
+  });
+  assert.equal(
+    result.status,
+    0,
+    `git ${args.join(' ')} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  return result;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
## 요약
- HOP의 rhwp 기준을 v0.7.8에서 v0.7.9로 올렸습니다.
- `third_party/rhwp`, `@rhwp/core`, desktop `Cargo.lock`의 rhwp 버전을 함께 맞췄습니다.
- HOP의 `main.ts` override 때문에 가려져 있던 upstream rhwp-studio의 문서 검증/lineseg 자동 보정 흐름을 복원했습니다.
- baseline 테스트를 추가해 submodule, WASM package, native lockfile, upstream 문서, HOP `main.ts`가 다시 어긋나지 않도록 했습니다.

## 배경
HOP는 rhwp 기반이지만, 실제로는 HOP의 `main.ts` override가 upstream rhwp-studio의 문서 검증 및 lineseg 자동 보정 흐름을 덮고 있었습니다.

또한 HOP 쪽 `@rhwp/core`와 submodule 기준이 v0.7.8에 머물러 있어, v0.7.9에 포함된 줄바꿈, 표/문단 배치, cell padding, lineseg 관련 렌더링 보정이 반영되지 않았습니다.

## 변경 내용
- `@rhwp/core`를 `0.7.9`로 업데이트
- `third_party/rhwp`를 `v0.7.9` 커밋으로 업데이트
- desktop `Cargo.lock`의 `rhwp` 버전 정합성 반영
- 문서 로드 후 validation warning이 있으면 사용자에게 알리고, 명시적으로 선택한 경우 `reflowLinesegs()` 실행 후 문서를 다시 렌더링하도록 복원
- `tests/rhwp-baseline.test.mjs` 추가

## 검증
- `pnpm run test:upstream`
- `pnpm run test:studio`
- `pnpm run build:studio`
- `pnpm run test:desktop`
- `pnpm run clippy:desktop`
<img width="980" height="711" alt="스크린샷 2026-05-02 오후 8 34 14" src="https://github.com/user-attachments/assets/a1fe870a-4560-4413-b173-fa0d0373560c" />
이렇게 출력 되던게
<img width="1370" height="775" alt="스크린샷 2026-05-02 오후 8 33 39" src="https://github.com/user-attachments/assets/044c8283-7f88-4955-b941-ccfba9105f6c" />
이렇게 출력 됩니다.