### PR TITLE
최근 문서 기능 추가 및 홈 화면 최근 문서 UX 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HOP
 
-**HOP is Open HWP**
+**HWP/HWPX 문서를 위한 데스크톱 편집기**
 
 HOP는 HWP/HWPX 문서를 보고 편집할 수 있는 오픈소스 macOS, Windows, Linux용 데스크탑 앱입니다.
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "hop-desktop",
   "version": "0.1.11",
   "private": true,
-  "description": "HOP - Open HWP desktop app",
+  "description": "HOP desktop editor for HWP and HWPX documents",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hop-desktop"
 version = "0.1.11"
 edition = "2021"
-description = "HOP - Open HWP desktop app"
+description = "HOP desktop editor for HWP and HWPX documents"
 license = "MIT"
 
 [lib]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1,4 +1,5 @@
 use crate::font_catalog::LocalFontEntry;
+use crate::recent_documents::{self, RecentDocument};
 use crate::state::{
     editable_core_from_bytes, AppState, DocumentFormat, DocumentOpenResult,
     ExternalModificationStatus, FileFingerprint, MutationResult, PageSvgResult, SaveResult,
@@ -43,11 +44,12 @@ pub fn open_document_tracking(
     source_fingerprint: Option<FileFingerprint>,
     state: State<'_, AppState>,
 ) -> Result<DocumentOpenResult, String> {
+    let path = PathBuf::from(path);
     state
         .sessions
         .lock()
         .map_err(|_| "문서 세션 잠금 실패".to_string())?
-        .open_document_tracking(PathBuf::from(path), source_fingerprint)
+        .open_document_tracking(path, source_fingerprint)
 }
 
 #[tauri::command]
@@ -108,6 +110,7 @@ pub fn prepare_staged_hwp_pdf_export(
 
 #[tauri::command]
 pub fn commit_staged_hwp_save(
+    app: AppHandle,
     doc_id: String,
     staged_path: String,
     target_path: String,
@@ -116,17 +119,44 @@ pub fn commit_staged_hwp_save(
     state: State<'_, AppState>,
 ) -> Result<SaveResult, String> {
     let target_path = PathBuf::from(target_path);
-    state
+    let result = state
         .sessions
         .lock()
         .map_err(|_| "문서 세션 잠금 실패".to_string())?
         .commit_staged_hwp_save(
             &doc_id,
             PathBuf::from(staged_path),
-            target_path,
+            target_path.clone(),
             expected_revision,
             allow_external_overwrite.unwrap_or(false),
-        )
+        )?;
+    let _ = recent_documents::record_document(&app, &target_path);
+    Ok(result)
+}
+
+#[tauri::command]
+pub fn list_recent_documents(app: AppHandle) -> Result<Vec<RecentDocument>, String> {
+    recent_documents::list_documents(&app)
+}
+
+#[tauri::command]
+pub fn clear_recent_documents(app: AppHandle) -> Result<(), String> {
+    recent_documents::clear_documents(&app)
+}
+
+#[tauri::command]
+pub fn record_recent_document(app: AppHandle, path: String) -> Result<(), String> {
+    recent_documents::record_document(&app, &PathBuf::from(path))
+}
+
+#[tauri::command]
+pub fn render_document_preview(path: String) -> Result<String, String> {
+    let path = PathBuf::from(path);
+    let bytes = std::fs::read(&path)
+        .map_err(|e| format!("미리보기용 문서를 읽을 수 없습니다: {} ({})", path.display(), e))?;
+    let core = editable_core_from_bytes(&bytes, "문서 파싱 실패", "미리보기용 문서 변환 실패")?;
+    core.render_page_svg_native(0)
+        .map_err(|e| format!("문서 미리보기를 렌더링할 수 없습니다: {}", e))
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod menu;
 mod pdf_export;
 mod pdf_font_fallbacks;
 mod pending_open;
+mod recent_documents;
 mod state;
 #[cfg(any(target_os = "macos", windows, target_os = "linux"))]
 mod updates;
@@ -20,12 +21,14 @@ use tauri::RunEvent;
 use tauri::{AppHandle, Emitter, Manager};
 
 use commands::{
-    cancel_app_quit, check_external_modification, close_document, commit_staged_hwp_save,
-    create_document, create_editor_window, desktop_platform, destroy_current_window, export_pdf,
-    export_pdf_from_hwp_path, list_local_fonts, mark_document_dirty, mutate_document,
+    cancel_app_quit, check_external_modification, clear_recent_documents, close_document,
+    commit_staged_hwp_save, create_document, create_editor_window, desktop_platform,
+    destroy_current_window, export_pdf, export_pdf_from_hwp_path, list_local_fonts,
+    list_recent_documents, mark_document_dirty, mutate_document,
     open_document_tracking, prepare_document_open, prepare_staged_hwp_pdf_export,
-    prepare_staged_hwp_save, print_webview, query_document, read_local_font, render_page_svg,
-    reveal_in_folder, take_pending_open_paths,
+    prepare_staged_hwp_save, print_webview, query_document, read_local_font,
+    record_recent_document, render_document_preview, render_page_svg, reveal_in_folder,
+    take_pending_open_paths,
 };
 use state::AppState;
 use updates::{get_update_state, restart_to_apply_update, start_update_install};
@@ -97,6 +100,10 @@ pub fn run() {
             check_external_modification,
             take_pending_open_paths,
             reveal_in_folder,
+            list_recent_documents,
+            clear_recent_documents,
+            record_recent_document,
+            render_document_preview,
             get_update_state,
             start_update_install,
             restart_to_apply_update,

--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -15,6 +15,9 @@ pub fn install(app: &mut App) -> tauri::Result<()> {
     let open = MenuItemBuilder::with_id("file:open", "Open...")
         .accelerator("CmdOrCtrl+O")
         .build(app)?;
+    let open_recent = MenuItemBuilder::with_id("file:open-recent", "Open Recent...")
+        .accelerator("CmdOrCtrl+Alt+O")
+        .build(app)?;
     let save = MenuItemBuilder::with_id("file:save", "Save")
         .accelerator("CmdOrCtrl+S")
         .build(app)?;
@@ -78,6 +81,7 @@ pub fn install(app: &mut App) -> tauri::Result<()> {
         .item(&new_window)
         .separator()
         .item(&open)
+        .item(&open_recent)
         .item(&save)
         .item(&save_as)
         .separator()

--- a/apps/desktop/src-tauri/src/recent_documents.rs
+++ b/apps/desktop/src-tauri/src/recent_documents.rs
@@ -1,0 +1,206 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Manager};
+
+const RECENT_DOCUMENTS_FILE: &str = "recent-documents.json";
+const MAX_RECENT_DOCUMENTS: usize = 10;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecentDocument {
+    pub path: String,
+    pub file_name: String,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RecentDocumentStore {
+    documents: Vec<RecentDocument>,
+}
+
+pub fn list_documents(app: &AppHandle) -> Result<Vec<RecentDocument>, String> {
+    list_documents_at(&store_path(app)?)
+}
+
+pub fn clear_documents(app: &AppHandle) -> Result<(), String> {
+    write_store(&store_path(app)?, &RecentDocumentStore::default())
+}
+
+pub fn record_document(app: &AppHandle, path: &Path) -> Result<(), String> {
+    record_document_at(&store_path(app)?, path)
+}
+
+fn store_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("최근 문서 저장 위치를 찾을 수 없습니다: {}", e))?;
+    Ok(dir.join(RECENT_DOCUMENTS_FILE))
+}
+
+fn list_documents_at(store_path: &Path) -> Result<Vec<RecentDocument>, String> {
+    let store = read_store(store_path)?;
+    Ok(store
+        .documents
+        .into_iter()
+        .filter(|document| is_existing_supported_document(&document.path))
+        .take(MAX_RECENT_DOCUMENTS)
+        .collect())
+}
+
+fn record_document_at(store_path: &Path, path: &Path) -> Result<(), String> {
+    if !is_supported_document_path(path) {
+        return Ok(());
+    }
+
+    let normalized_path = normalized_document_path(path);
+    let Some(file_name) = Path::new(&normalized_path)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .map(str::to_string)
+    else {
+        return Ok(());
+    };
+
+    let mut documents = list_documents_at(store_path)?;
+    documents.retain(|document| !same_document_path(&document.path, &normalized_path));
+    documents.insert(
+        0,
+        RecentDocument {
+            path: normalized_path,
+            file_name,
+        },
+    );
+    documents.truncate(MAX_RECENT_DOCUMENTS);
+    write_store(store_path, &RecentDocumentStore { documents })
+}
+
+fn read_store(store_path: &Path) -> Result<RecentDocumentStore, String> {
+    match fs::read_to_string(store_path) {
+        Ok(content) => serde_json::from_str(&content)
+            .map_err(|e| format!("최근 문서 목록을 읽을 수 없습니다: {}", e)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(RecentDocumentStore::default())
+        }
+        Err(error) => Err(format!("최근 문서 목록을 읽을 수 없습니다: {}", error)),
+    }
+}
+
+fn write_store(store_path: &Path, store: &RecentDocumentStore) -> Result<(), String> {
+    if let Some(parent) = store_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("최근 문서 저장 위치를 만들 수 없습니다: {}", e))?;
+    }
+    let content = serde_json::to_vec_pretty(store)
+        .map_err(|e| format!("최근 문서 목록을 저장할 수 없습니다: {}", e))?;
+    fs::write(store_path, content).map_err(|e| format!("최근 문서 목록을 저장할 수 없습니다: {}", e))
+}
+
+fn is_existing_supported_document(path: &str) -> bool {
+    let path = Path::new(path);
+    path.is_file() && is_supported_document_path(path)
+}
+
+fn is_supported_document_path(path: &Path) -> bool {
+    matches!(
+        path.extension()
+            .and_then(|value| value.to_str())
+            .map(|value| value.to_ascii_lowercase())
+            .as_deref(),
+        Some("hwp" | "hwpx")
+    )
+}
+
+fn normalized_document_path(path: &Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .to_string()
+}
+
+fn same_document_path(left: &str, right: &str) -> bool {
+    if cfg!(windows) {
+        left.eq_ignore_ascii_case(right)
+    } else {
+        left == right
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_document_keeps_most_recent_first_and_deduplicates() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("recent.json");
+        let first = dir.path().join("first.hwp");
+        let second = dir.path().join("second.hwpx");
+        fs::write(&first, b"first").unwrap();
+        fs::write(&second, b"second").unwrap();
+
+        record_document_at(&store, &first).unwrap();
+        record_document_at(&store, &second).unwrap();
+        record_document_at(&store, &first).unwrap();
+
+        let documents = list_documents_at(&store).unwrap();
+        assert_eq!(documents.len(), 2);
+        assert_eq!(documents[0].file_name, "first.hwp");
+        assert_eq!(documents[1].file_name, "second.hwpx");
+    }
+
+    #[test]
+    fn list_documents_filters_missing_and_unsupported_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("recent.json");
+        let kept = dir.path().join("kept.hwp");
+        let unsupported = dir.path().join("notes.txt");
+        fs::write(&kept, b"kept").unwrap();
+        fs::write(&unsupported, b"notes").unwrap();
+        write_store(
+            &store,
+            &RecentDocumentStore {
+                documents: vec![
+                    RecentDocument {
+                        path: unsupported.to_string_lossy().to_string(),
+                        file_name: "notes.txt".to_string(),
+                    },
+                    RecentDocument {
+                        path: dir.path().join("missing.hwpx").to_string_lossy().to_string(),
+                        file_name: "missing.hwpx".to_string(),
+                    },
+                    RecentDocument {
+                        path: kept.to_string_lossy().to_string(),
+                        file_name: "kept.hwp".to_string(),
+                    },
+                ],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            list_documents_at(&store).unwrap(),
+            vec![RecentDocument {
+                path: kept.to_string_lossy().to_string(),
+                file_name: "kept.hwp".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn record_document_limits_list_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("recent.json");
+        for index in 0..12 {
+            let path = dir.path().join(format!("doc-{index}.hwp"));
+            fs::write(&path, b"doc").unwrap();
+            record_document_at(&store, &path).unwrap();
+        }
+
+        let documents = list_documents_at(&store).unwrap();
+        assert_eq!(documents.len(), MAX_RECENT_DOCUMENTS);
+        assert_eq!(documents[0].file_name, "doc-11.hwp");
+        assert_eq!(documents[9].file_name, "doc-2.hwp");
+    }
+}

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
     "targets": "all",
     "publisher": "golbin.net",
     "shortDescription": "Open desktop editor for HWP and HWPX documents",
-    "longDescription": "HOP is Open HWP. HOP opens, edits, saves, and exports HWP/HWPX documents.",
+    "longDescription": "HOP opens, edits, saves, and exports HWP/HWPX documents.",
     "category": "Productivity",
     "copyright": "Copyright (c) 2026 HOP contributors",
     "icon": [

--- a/apps/studio-host/hop-overrides.ts
+++ b/apps/studio-host/hop-overrides.ts
@@ -24,7 +24,9 @@ const overrideIds = [
   'ui/about-dialog',
   'ui/custom-select',
   'ui/dialog',
+  'ui/home-screen',
   'ui/print-dialog',
+  'ui/recent-documents-dialog',
   'ui/style-edit-dialog',
   'ui/toolbar',
   'ui/update-notice',
@@ -33,7 +35,9 @@ const overrideIds = [
   'styles/about-dialog.css',
   'styles/custom-select.css',
   'styles/font-set-dialog.css',
+  'styles/home-screen.css',
   'styles/update-notice.css',
+  'styles/recent-documents-dialog.css',
 ] as const;
 
 export function createHopOverrides(hopSrc: string) {

--- a/apps/studio-host/index.html
+++ b/apps/studio-host/index.html
@@ -18,6 +18,7 @@
           <div class="md-item disabled" data-cmd="file:new-doc"><span class="md-icon icon-new-doc"></span><span class="md-label">새로 만들기</span></div>
           <div class="md-item" data-cmd="file:new-window"><span class="md-icon"></span><span class="md-label">새 창</span><span class="md-shortcut">Ctrl+Shift+N</span></div>
           <div class="md-item" data-cmd="file:open"><span class="md-icon"></span><span class="md-label">열기</span><span class="md-shortcut">Ctrl+O</span></div>
+          <div class="md-item" data-cmd="file:open-recent"><span class="md-icon"></span><span class="md-label">최근 문서</span><span class="md-shortcut">Ctrl+Alt+O</span></div>
           <div class="md-item disabled" data-cmd="file:save"><span class="md-icon icon-save"></span><span class="md-label">저장</span><span class="md-shortcut">Ctrl+S</span></div>
           <div class="md-item disabled" data-cmd="file:save-as"><span class="md-icon"></span><span class="md-label">다른 이름으로 저장</span><span class="md-shortcut">Ctrl+Shift+S</span></div>
           <div class="md-sep"></div>

--- a/apps/studio-host/src/command/commands/file.test.ts
+++ b/apps/studio-host/src/command/commands/file.test.ts
@@ -4,6 +4,7 @@ import { fileCommands } from './file';
 const upstreamOpen = vi.hoisted(() => vi.fn());
 const upstreamSave = vi.hoisted(() => vi.fn());
 const openPrintDialog = vi.hoisted(() => vi.fn());
+const openRecentDocumentsDialog = vi.hoisted(() => vi.fn());
 
 vi.mock('@upstream/command/commands/file', () => ({
   fileCommands: [
@@ -17,9 +18,15 @@ vi.mock('@/ui/print-dialog', () => ({
   openPrintDialog,
 }));
 
+vi.mock('@/ui/recent-documents-dialog', () => ({
+  openRecentDocumentsDialog,
+}));
+
 describe('file command desktop overrides', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    openPrintDialog.mockReset();
+    openRecentDocumentsDialog.mockReset();
     (globalThis as { alert?: unknown }).alert = vi.fn();
     (globalThis as { window?: unknown }).window = { location: { href: 'http://localhost/' }, open: vi.fn() };
     (globalThis as { document?: unknown }).document = {
@@ -90,6 +97,42 @@ describe('file command desktop overrides', () => {
     await command('file:export-pdf').execute(services({ wasm: {} }) as never);
 
     expect(globalThis.alert).toHaveBeenCalledWith('PDF 내보내기는 HOP 데스크톱 앱에서 지원합니다.');
+  });
+
+  it('opens a selected recent document through the desktop bridge', async () => {
+    const loaded = { docInfo: { pageCount: 1 }, message: 'loaded' };
+    const recent = { path: '/tmp/recent.hwp', fileName: 'recent.hwp' };
+    const eventBus = { emit: vi.fn() };
+    const wasm = {
+      openDocumentByPath: vi.fn().mockResolvedValue(loaded),
+      listRecentDocuments: vi.fn().mockResolvedValue([recent]),
+      clearRecentDocuments: vi.fn(),
+    };
+    openRecentDocumentsDialog.mockResolvedValue(recent);
+
+    await command('file:open-recent').execute(services({ wasm, eventBus }) as never);
+
+    expect(openRecentDocumentsDialog).toHaveBeenCalledWith(
+      [recent],
+      expect.objectContaining({ clearRecentDocuments: expect.any(Function) }),
+    );
+    expect(wasm.openDocumentByPath).toHaveBeenCalledWith('/tmp/recent.hwp');
+    expect(eventBus.emit).toHaveBeenCalledWith('desktop-document-loaded', loaded);
+  });
+
+  it('reports an empty recent document list without opening the dialog', async () => {
+    const eventBus = { emit: vi.fn() };
+    const wasm = {
+      openDocumentByPath: vi.fn(),
+      listRecentDocuments: vi.fn().mockResolvedValue([]),
+      clearRecentDocuments: vi.fn(),
+    };
+
+    await command('file:open-recent').execute(services({ wasm, eventBus }) as never);
+
+    expect(openRecentDocumentsDialog).not.toHaveBeenCalled();
+    expect(wasm.openDocumentByPath).not.toHaveBeenCalled();
+    expect(eventBus.emit).toHaveBeenCalledWith('desktop-status', '최근 문서가 없습니다');
   });
 });
 

--- a/apps/studio-host/src/command/commands/file.ts
+++ b/apps/studio-host/src/command/commands/file.ts
@@ -2,6 +2,7 @@ import { fileCommands as upstreamFileCommands } from '@upstream/command/commands
 import type { CommandDef, CommandServices } from '@/command/types';
 import type { DesktopBridgeApi } from '@/core/tauri-bridge';
 import { openPrintDialog } from '@/ui/print-dialog';
+import { openRecentDocumentsDialog } from '@/ui/recent-documents-dialog';
 
 type DesktopFileBridge = Pick<
   DesktopBridgeApi,
@@ -11,6 +12,13 @@ type DesktopFileBridge = Pick<
   | 'saveDocumentAsFromCommand'
   | 'exportPdfFromCommand'
   | 'printCurrentWebview'
+>;
+
+type DesktopRecentBridge = Pick<
+  DesktopBridgeApi,
+  | 'openDocumentByPath'
+  | 'listRecentDocuments'
+  | 'clearRecentDocuments'
 >;
 
 const upstreamById = new Map(upstreamFileCommands.map((command) => [command.id, command]));
@@ -25,6 +33,16 @@ function desktopBridge(wasm: unknown): DesktopFileBridge | null {
     && typeof candidate.exportPdfFromCommand === 'function'
     && typeof candidate.printCurrentWebview === 'function'
     ? candidate as DesktopFileBridge
+    : null;
+}
+
+function recentBridge(wasm: unknown): DesktopRecentBridge | null {
+  if (!wasm || typeof wasm !== 'object') return null;
+  const candidate = wasm as Partial<DesktopRecentBridge>;
+  return typeof candidate.openDocumentByPath === 'function'
+    && typeof candidate.listRecentDocuments === 'function'
+    && typeof candidate.clearRecentDocuments === 'function'
+    ? candidate as DesktopRecentBridge
     : null;
 }
 
@@ -108,6 +126,43 @@ const hopOnlyCommands: CommandDef[] = [
         return;
       }
       await desktop.createNewWindow();
+    },
+  },
+  {
+    id: 'file:open-recent',
+    label: '최근 문서',
+    shortcutLabel: 'Ctrl+Alt+O',
+    async execute(services) {
+      const desktop = recentBridge(services.wasm);
+      if (!desktop) {
+        alert('최근 문서는 HOP 데스크톱 앱에서 지원합니다.');
+        return;
+      }
+
+      try {
+        const documents = await desktop.listRecentDocuments();
+        if (documents.length === 0) {
+          emitStatus(services, '최근 문서가 없습니다');
+          alert('최근 문서가 없습니다.');
+          return;
+        }
+
+        const selected = await openRecentDocumentsDialog(documents, {
+          clearRecentDocuments: () => desktop.clearRecentDocuments(),
+        });
+        if (!selected) {
+          emitStatus(services, '최근 문서 목록을 닫았습니다');
+          return;
+        }
+
+        emitStatus(services, '파일 로딩 중...');
+        const payload = await desktop.openDocumentByPath(selected.path);
+        if (payload) {
+          services.eventBus.emit('desktop-document-loaded', payload);
+        }
+      } catch (error) {
+        reportCommandError(services, '최근 문서 열기', error);
+      }
     },
   },
   {

--- a/apps/studio-host/src/command/shortcut-map.test.ts
+++ b/apps/studio-host/src/command/shortcut-map.test.ts
@@ -14,6 +14,8 @@ describe('shortcut-map', () => {
     expect(matchShortcut(keyEvent({ key: 's', metaKey: true }), defaultShortcuts)).toBe('file:save');
     expect(matchShortcut(keyEvent({ key: 'n', metaKey: true, shiftKey: true }), defaultShortcuts))
       .toBe('file:new-window');
+    expect(matchShortcut(keyEvent({ key: 'o', metaKey: true, altKey: true }), defaultShortcuts))
+      .toBe('file:open-recent');
     expect(matchShortcut(keyEvent({ key: 't', metaKey: true, altKey: true }), defaultShortcuts))
       .toBe('table:cell-selection-enter');
   });

--- a/apps/studio-host/src/command/shortcut-map.ts
+++ b/apps/studio-host/src/command/shortcut-map.ts
@@ -9,6 +9,7 @@ export type { ShortcutDef };
 const hopShortcuts: [ShortcutDef, string][] = [
   [{ key: 'n', ctrl: true, shift: true }, 'file:new-window'],
   [{ key: 'o', ctrl: true }, 'file:open'],
+  [{ key: 'o', ctrl: true, alt: true }, 'file:open-recent'],
   [{ key: 's', ctrl: true, shift: true }, 'file:save-as'],
   [{ key: 'e', ctrl: true }, 'file:export-pdf'],
   [{ key: 't', ctrl: true, alt: true }, 'table:cell-selection-enter'],

--- a/apps/studio-host/src/core/tauri-bridge.test.ts
+++ b/apps/studio-host/src/core/tauri-bridge.test.ts
@@ -82,6 +82,9 @@ describe('TauriBridge', () => {
         contentHash: hashBytes(new Uint8Array([10, 20, 30])),
       },
     });
+    expect(invokeMock).toHaveBeenCalledWith('record_recent_document', {
+      path: '/tmp/opened.hwp',
+    });
     expect(getWasmMock(bridge, 'loadDocumentMock')).toHaveBeenCalledWith(
       new Uint8Array([10, 20, 30]),
       'opened.hwp',
@@ -155,12 +158,17 @@ describe('TauriBridge', () => {
     fsOpenMock
       .mockResolvedValueOnce(readHandle([1]))
       .mockResolvedValueOnce(readHandle([2]));
-    invokeMock
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(nativeOpenResult({ docId: 'old-doc', fileName: 'old.hwp' }))
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(nativeOpenResult({ docId: 'new-doc', fileName: 'new.hwp' }))
-      .mockResolvedValueOnce(undefined);
+    invokeMock.mockImplementation(async (command: string, args: Record<string, unknown>) => {
+      if (command === 'prepare_document_open') return undefined;
+      if (command === 'record_recent_document') return undefined;
+      if (command === 'close_document') return undefined;
+      if (command === 'open_document_tracking') {
+        return args.path === '/tmp/old.hwp'
+          ? nativeOpenResult({ docId: 'old-doc', fileName: 'old.hwp' })
+          : nativeOpenResult({ docId: 'new-doc', fileName: 'new.hwp' });
+      }
+      throw new Error(`unexpected command ${command}`);
+    });
 
     await bridge.openDocumentByPath('/tmp/old.hwp');
     await bridge.openDocumentByPath('/tmp/new.hwp');
@@ -252,6 +260,20 @@ describe('TauriBridge', () => {
     expect(invokeMock).toHaveBeenNthCalledWith(2, 'start_update_install', {});
     expect(invokeMock).toHaveBeenNthCalledWith(3, 'restart_to_apply_update', {});
     expect(invokeMock).toHaveBeenNthCalledWith(4, 'cancel_app_quit', {});
+  });
+
+  it('proxies recent document commands through the Tauri bridge', async () => {
+    const bridge = new TauriBridge();
+    const documents = [{ path: '/tmp/recent.hwp', fileName: 'recent.hwp' }];
+    invokeMock
+      .mockResolvedValueOnce(documents)
+      .mockResolvedValueOnce(undefined);
+
+    await expect(bridge.listRecentDocuments()).resolves.toEqual(documents);
+    await expect(bridge.clearRecentDocuments()).resolves.toBeUndefined();
+
+    expect(invokeMock).toHaveBeenNthCalledWith(1, 'list_recent_documents', {});
+    expect(invokeMock).toHaveBeenNthCalledWith(2, 'clear_recent_documents', {});
   });
 
   it('blocks direct save for HWPX sources', async () => {

--- a/apps/studio-host/src/core/tauri-bridge.ts
+++ b/apps/studio-host/src/core/tauri-bridge.ts
@@ -59,6 +59,11 @@ export interface DesktopSaveResult {
   warnings: unknown[];
 }
 
+export interface RecentDocument {
+  path: string;
+  fileName: string;
+}
+
 export interface DesktopLoadPayload {
   docInfo: DocumentInfo;
   message: string;
@@ -77,6 +82,9 @@ export interface DesktopBridgeApi {
   destroyCurrentWindow(): Promise<void>;
   cancelAppQuit(): Promise<void>;
   revealInFolder(): Promise<void>;
+  listRecentDocuments(): Promise<RecentDocument[]>;
+  clearRecentDocuments(): Promise<void>;
+  renderDocumentPreview(path: string): Promise<string>;
   getUpdateState(): Promise<DesktopUpdateState>;
   startUpdateInstall(): Promise<void>;
   restartToApplyUpdate(): Promise<void>;
@@ -115,6 +123,7 @@ export class TauriBridge extends WasmBridge implements DesktopBridgeApi {
     try {
       const info = super.loadDocument(bytes, result.fileName);
       this.applyNativeOpenResult(result);
+      await this.recordRecentDocument(path);
       await this.closeReplacedDocument(previousDocId, result.docId);
       return {
         docInfo: info,
@@ -209,6 +218,18 @@ export class TauriBridge extends WasmBridge implements DesktopBridgeApi {
     await this.invoke<void>('reveal_in_folder', { path: this.sourcePath });
   }
 
+  async listRecentDocuments(): Promise<RecentDocument[]> {
+    return this.invoke<RecentDocument[]>('list_recent_documents');
+  }
+
+  async clearRecentDocuments(): Promise<void> {
+    await this.invoke<void>('clear_recent_documents');
+  }
+
+  async renderDocumentPreview(path: string): Promise<string> {
+    return this.invoke<string>('render_document_preview', { path });
+  }
+
   async getUpdateState(): Promise<DesktopUpdateState> {
     return this.invoke<DesktopUpdateState>('get_update_state');
   }
@@ -251,6 +272,12 @@ export class TauriBridge extends WasmBridge implements DesktopBridgeApi {
     } catch (error) {
       console.warn('[TauriBridge] native document cleanup failed:', error);
     }
+  }
+
+  private async recordRecentDocument(path: string): Promise<void> {
+    await this.invoke<void>('record_recent_document', { path }).catch((error: unknown) => {
+      console.warn('[TauriBridge] recent document update failed:', error);
+    });
   }
 
   private async closeReplacedDocument(previousDocId: string | null, nextDocId: string): Promise<void> {

--- a/apps/studio-host/src/main.ts
+++ b/apps/studio-host/src/main.ts
@@ -33,6 +33,7 @@ import { TableResizeRenderer } from '@/engine/table-resize-renderer';
 import { Ruler } from '@/view/ruler';
 import { enhanceCustomSelects } from '@/ui/custom-select';
 import { UpdateNotice, type UpdateNoticeActions } from '@/ui/update-notice';
+import { HomeScreen } from '@/ui/home-screen';
 import type { DesktopBridgeApi } from '@/core/tauri-bridge';
 
 const wasm = createBridge();
@@ -53,6 +54,7 @@ let canvasView: CanvasView | null = null;
 let inputHandler: InputHandler | null = null;
 let toolbar: Toolbar | null = null;
 let ruler: Ruler | null = null;
+let homeScreen: HomeScreen | null = null;
 
 
 // ─── 커맨드 시스템 ─────────────────────────────
@@ -116,6 +118,20 @@ async function initialize(): Promise<void> {
 
     const container = document.getElementById('scroll-container')!;
     canvasView = new CanvasView(container, wasm, eventBus);
+    homeScreen = new HomeScreen(container, wasm, {
+      openFile: () => {
+        dispatcher.dispatch('file:open');
+      },
+      createNewDocument: () => {
+        dispatcher.dispatch('file:new-doc');
+      },
+      onDocumentLoaded: (payload) => {
+        eventBus.emit('desktop-document-loaded', payload);
+      },
+      setMessage: (message) => {
+        sbMessage().textContent = message;
+      },
+    });
 
     // 눈금자 초기화
     ruler = new Ruler(
@@ -215,7 +231,13 @@ async function initialize(): Promise<void> {
       },
     }).catch((error) => {
       console.error('[main] desktop event setup failed:', error);
+    }).finally(() => {
+      void homeScreen?.refresh(wasm.pageCount > 0);
     });
+
+    if (!isTauriRuntime()) {
+      void homeScreen.refresh(false);
+    }
 
     // E2E 테스트용 전역 노출 (개발 모드 전용)
     if (import.meta.env.DEV) {
@@ -273,15 +295,16 @@ function setupGlobalShortcuts(): void {
       }
     }
 
-    if (primaryModifier && !e.altKey) {
+    if (primaryModifier) {
       let commandId: string | null = null;
       const key = e.key.toLowerCase();
-      if (e.shiftKey && key === 'n') commandId = 'file:new-window';
-      else if (!e.shiftKey && key === 'o') commandId = 'file:open';
-      else if (!e.shiftKey && key === 's') commandId = 'file:save';
-      else if (e.shiftKey && key === 's') commandId = 'file:save-as';
-      else if (!e.shiftKey && key === 'e') commandId = 'file:export-pdf';
-      else if (!e.shiftKey && key === 'p') commandId = 'file:print';
+      if (e.shiftKey && !e.altKey && key === 'n') commandId = 'file:new-window';
+      else if (!e.shiftKey && e.altKey && key === 'o') commandId = 'file:open-recent';
+      else if (!e.shiftKey && !e.altKey && key === 'o') commandId = 'file:open';
+      else if (!e.shiftKey && !e.altKey && key === 's') commandId = 'file:save';
+      else if (e.shiftKey && !e.altKey && key === 's') commandId = 'file:save-as';
+      else if (!e.shiftKey && !e.altKey && key === 'e') commandId = 'file:export-pdf';
+      else if (!e.shiftKey && !e.altKey && key === 'p') commandId = 'file:print';
 
       if (commandId) {
         e.preventDefault();
@@ -516,6 +539,7 @@ async function initializeDocument(docInfo: DocumentInfo, displayName: string): P
     msg.textContent = displayName;
     totalSections = docInfo.sectionCount ?? 1;
     sbSection().textContent = `구역: 1 / ${totalSections}`;
+    void homeScreen?.refresh(true);
     inputHandler?.deactivate();
     canvasView?.loadDocument();
     toolbar?.setEnabled(true);

--- a/apps/studio-host/src/style.css
+++ b/apps/studio-host/src/style.css
@@ -22,5 +22,7 @@
 @import '@/styles/command-palette.css';
 @import '@/styles/about-dialog.css';
 @import '@/styles/custom-select.css';
+@import '@/styles/home-screen.css';
 @import '@/styles/update-notice.css';
+@import '@/styles/recent-documents-dialog.css';
 @import '@/styles/responsive.css';

--- a/apps/studio-host/src/styles/home-screen.css
+++ b/apps/studio-host/src/styles/home-screen.css
@@ -2,67 +2,56 @@
   position: absolute;
   inset: 0;
   overflow: auto;
-  padding: 40px 48px 56px;
-  background:
-    radial-gradient(circle at top left, rgba(97, 130, 214, 0.12), transparent 28%),
-    linear-gradient(180deg, #f7f8fb 0%, #eef1f5 100%);
+  padding: 32px 40px 48px;
+  background: var(--color-hover-bg);
   color: var(--color-text);
 }
 
 .home-hero {
-  max-width: 880px;
-  margin-bottom: 32px;
-}
-
-.home-eyebrow {
-  margin-bottom: 12px;
-  color: var(--color-primary-dark);
-  font-size: var(--font-size-md);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  max-width: 760px;
+  margin-bottom: 24px;
 }
 
 .home-title {
-  max-width: 760px;
-  margin-bottom: 12px;
-  font-size: 34px;
-  font-weight: 800;
-  line-height: 1.15;
+  max-width: 720px;
+  margin-bottom: 10px;
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1.3;
 }
 
 .home-subtitle {
-  max-width: 720px;
-  margin-bottom: 22px;
+  max-width: 640px;
+  margin-bottom: 18px;
   color: var(--color-text-secondary);
-  font-size: 16px;
+  font-size: var(--font-size-lg);
   line-height: 1.5;
 }
 
 .home-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 8px;
 }
 
 .home-action {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  min-width: 220px;
-  padding: 14px 16px;
-  border: 1px solid rgba(74, 92, 138, 0.16);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.86);
-  box-shadow: 0 12px 30px rgba(51, 80, 149, 0.08);
+  min-width: 200px;
+  padding: 12px 14px;
+  border: 1px solid #c8c8c8;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(to bottom, var(--color-surface), var(--color-surface-raised));
   color: inherit;
   text-align: left;
   cursor: default;
 }
 
 .home-action:hover {
-  border-color: rgba(74, 92, 138, 0.28);
-  background: rgba(255, 255, 255, 0.94);
+  border-color: #96a6cd;
+  background: #e9eefb;
+  color: var(--color-primary-dark);
 }
 
 .home-action-title {
@@ -90,14 +79,18 @@
 }
 
 .home-section-title {
-  font-size: 22px;
-  font-weight: 800;
+  font-size: 18px;
+  font-weight: 700;
 }
 
 .home-recent-pagination {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
+}
+
+.home-recent-pagination[hidden] {
+  display: none;
 }
 
 .home-recent-page-label {
@@ -109,26 +102,27 @@
 }
 
 .home-recent-page-btn {
-  min-width: 58px;
-  height: 32px;
-  padding: 0 12px;
-  border: 1px solid rgba(74, 92, 138, 0.18);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.84);
+  min-width: 48px;
+  height: 24px;
+  padding: 0 10px;
+  border: 1px solid #c8c8c8;
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-raised);
   color: var(--color-text);
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 400;
   cursor: default;
 }
 
 .home-recent-page-btn:hover:enabled {
-  border-color: rgba(74, 92, 138, 0.32);
-  background: rgba(255, 255, 255, 0.96);
+  border-color: #96a6cd;
+  background: #e9eefb;
+  color: var(--color-primary-dark);
 }
 
 .home-recent-page-btn:disabled {
   color: var(--color-text-disabled);
-  background: rgba(255, 255, 255, 0.66);
+  background: #f5f5f5;
 }
 
 .home-recent-hint {
@@ -159,12 +153,12 @@
   width: 100%;
   min-width: 0;
   padding: 0;
-  border: 1px solid rgba(92, 112, 156, 0.18);
-  border-radius: 8px;
+  border: 1px solid #c8c8c8;
+  border-radius: var(--radius-lg);
   -webkit-appearance: none;
   appearance: none;
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 18px 34px rgba(39, 52, 86, 0.08);
+  background: var(--color-surface);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
   color: inherit;
   font: inherit;
   text-align: left;
@@ -173,9 +167,8 @@
 }
 
 .home-recent-card:hover {
-  transform: translateY(-1px);
-  border-color: rgba(74, 92, 138, 0.3);
-  box-shadow: 0 20px 38px rgba(39, 52, 86, 0.12);
+  border-color: #96a6cd;
+  background: #fdfdfd;
 }
 
 .home-recent-card.is-placeholder {
@@ -187,7 +180,7 @@
   box-sizing: border-box;
   min-width: 0;
   padding: 18px 18px 14px;
-  border-bottom: 1px solid rgba(92, 112, 156, 0.12);
+  border-bottom: 1px solid #e0e0e0;
   overflow: hidden;
 }
 
@@ -216,19 +209,17 @@
   min-width: 0;
   aspect-ratio: 4 / 3;
   padding: 26px 22px 22px;
-  background:
-    linear-gradient(180deg, rgba(241, 244, 250, 0.7), rgba(252, 252, 253, 0.96)),
-    linear-gradient(135deg, rgba(97, 130, 214, 0.08), transparent 45%);
+  background: var(--color-bg-light);
 }
 
 .home-recent-preview::before {
   content: '';
   position: absolute;
   inset: 22px;
-  border: 1px solid rgba(118, 137, 182, 0.18);
-  border-radius: 4px;
-  background: white;
-  box-shadow: 0 8px 24px rgba(33, 43, 70, 0.08);
+  border: 1px solid #d0d0d0;
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
 .home-recent-preview.is-loaded {
@@ -246,9 +237,9 @@
 .home-recent-preview.is-loaded svg {
   width: 100%;
   height: 100%;
-  border-radius: 4px;
-  box-shadow: 0 8px 24px rgba(33, 43, 70, 0.08);
-  background: white;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  background: var(--color-surface);
 }
 
 .home-preview-line,
@@ -261,7 +252,7 @@
   height: 8px;
   margin: 0 18px 10px;
   border-radius: 999px;
-  background: linear-gradient(90deg, rgba(124, 146, 196, 0.95), rgba(204, 214, 233, 0.65));
+  background: #c0c8d8;
 }
 
 .home-preview-line.is-wide {
@@ -281,9 +272,9 @@
 
 .home-preview-cell {
   aspect-ratio: 1.2;
-  border: 1px solid rgba(124, 146, 196, 0.2);
+  border: 1px solid #d0d0d0;
   border-radius: 3px;
-  background: linear-gradient(180deg, rgba(247, 249, 253, 1), rgba(236, 240, 248, 1));
+  background: #f7f7f7;
 }
 
 .home-drop-hint {

--- a/apps/studio-host/src/styles/home-screen.css
+++ b/apps/studio-host/src/styles/home-screen.css
@@ -1,0 +1,334 @@
+.home-screen {
+  position: absolute;
+  inset: 0;
+  overflow: auto;
+  padding: 40px 48px 56px;
+  background:
+    radial-gradient(circle at top left, rgba(97, 130, 214, 0.12), transparent 28%),
+    linear-gradient(180deg, #f7f8fb 0%, #eef1f5 100%);
+  color: var(--color-text);
+}
+
+.home-hero {
+  max-width: 880px;
+  margin-bottom: 32px;
+}
+
+.home-eyebrow {
+  margin-bottom: 12px;
+  color: var(--color-primary-dark);
+  font-size: var(--font-size-md);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.home-title {
+  max-width: 760px;
+  margin-bottom: 12px;
+  font-size: 34px;
+  font-weight: 800;
+  line-height: 1.15;
+}
+
+.home-subtitle {
+  max-width: 720px;
+  margin-bottom: 22px;
+  color: var(--color-text-secondary);
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.home-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.home-action {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  min-width: 220px;
+  padding: 14px 16px;
+  border: 1px solid rgba(74, 92, 138, 0.16);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 12px 30px rgba(51, 80, 149, 0.08);
+  color: inherit;
+  text-align: left;
+  cursor: default;
+}
+
+.home-action:hover {
+  border-color: rgba(74, 92, 138, 0.28);
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.home-action-title {
+  margin-bottom: 4px;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.home-action-description {
+  color: var(--color-text-muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.home-recent {
+  margin-bottom: 28px;
+}
+
+.home-section-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.home-section-title {
+  font-size: 22px;
+  font-weight: 800;
+}
+
+.home-recent-pagination {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.home-recent-page-label {
+  min-width: 48px;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.home-recent-page-btn {
+  min-width: 58px;
+  height: 32px;
+  padding: 0 12px;
+  border: 1px solid rgba(74, 92, 138, 0.18);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.84);
+  color: var(--color-text);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: default;
+}
+
+.home-recent-page-btn:hover:enabled {
+  border-color: rgba(74, 92, 138, 0.32);
+  background: rgba(255, 255, 255, 0.96);
+}
+
+.home-recent-page-btn:disabled {
+  color: var(--color-text-disabled);
+  background: rgba(255, 255, 255, 0.66);
+}
+
+.home-recent-hint {
+  margin-bottom: 16px;
+  color: var(--color-text-muted);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.home-recent-track {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 18px;
+  align-items: stretch;
+  justify-content: start;
+  width: 100%;
+  max-width: 1772px;
+}
+
+.home-recent.is-empty .home-recent-track {
+  display: none;
+}
+
+.home-recent-card {
+  display: grid;
+  grid-template-rows: 104px auto;
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  border: 1px solid rgba(92, 112, 156, 0.18);
+  border-radius: 8px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 18px 34px rgba(39, 52, 86, 0.08);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  overflow: hidden;
+  cursor: default;
+}
+
+.home-recent-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(74, 92, 138, 0.3);
+  box-shadow: 0 20px 38px rgba(39, 52, 86, 0.12);
+}
+
+.home-recent-card.is-placeholder {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.home-recent-meta {
+  box-sizing: border-box;
+  min-width: 0;
+  padding: 18px 18px 14px;
+  border-bottom: 1px solid rgba(92, 112, 156, 0.12);
+  overflow: hidden;
+}
+
+.home-recent-name {
+  display: -webkit-box;
+  overflow: hidden;
+  margin-bottom: 8px;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.45;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.home-recent-path {
+  overflow: hidden;
+  color: var(--color-text-placeholder);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-recent-preview {
+  position: relative;
+  box-sizing: border-box;
+  min-width: 0;
+  aspect-ratio: 4 / 3;
+  padding: 26px 22px 22px;
+  background:
+    linear-gradient(180deg, rgba(241, 244, 250, 0.7), rgba(252, 252, 253, 0.96)),
+    linear-gradient(135deg, rgba(97, 130, 214, 0.08), transparent 45%);
+}
+
+.home-recent-preview::before {
+  content: '';
+  position: absolute;
+  inset: 22px;
+  border: 1px solid rgba(118, 137, 182, 0.18);
+  border-radius: 4px;
+  background: white;
+  box-shadow: 0 8px 24px rgba(33, 43, 70, 0.08);
+}
+
+.home-recent-preview.is-loaded {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  padding: 14px;
+  overflow: hidden;
+}
+
+.home-recent-preview.is-loaded::before {
+  display: none;
+}
+
+.home-recent-preview.is-loaded svg {
+  width: 100%;
+  height: 100%;
+  border-radius: 4px;
+  box-shadow: 0 8px 24px rgba(33, 43, 70, 0.08);
+  background: white;
+}
+
+.home-preview-line,
+.home-preview-grid {
+  position: relative;
+  z-index: 1;
+}
+
+.home-preview-line {
+  height: 8px;
+  margin: 0 18px 10px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(124, 146, 196, 0.95), rgba(204, 214, 233, 0.65));
+}
+
+.home-preview-line.is-wide {
+  width: calc(100% - 74px);
+}
+
+.home-preview-line.is-short {
+  width: 52%;
+}
+
+.home-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin: 18px 18px 0;
+}
+
+.home-preview-cell {
+  aspect-ratio: 1.2;
+  border: 1px solid rgba(124, 146, 196, 0.2);
+  border-radius: 3px;
+  background: linear-gradient(180deg, rgba(247, 249, 253, 1), rgba(236, 240, 248, 1));
+}
+
+.home-drop-hint {
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
+#scroll-container.home-visible {
+  overflow: hidden auto;
+}
+
+#scroll-container.home-visible #scroll-content {
+  display: none;
+}
+
+@media (max-width: 1280px) {
+  .home-recent-track {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    max-width: 1056px;
+  }
+}
+
+@media (max-width: 900px) {
+  .home-screen {
+    padding: 28px 20px 36px;
+  }
+
+  .home-title {
+    font-size: 26px;
+  }
+
+  .home-subtitle {
+    font-size: 14px;
+  }
+
+  .home-recent-track {
+    grid-template-columns: 1fr;
+  }
+
+  .home-recent-card.is-placeholder {
+    display: none;
+  }
+
+  .home-section-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/apps/studio-host/src/styles/recent-documents-dialog.css
+++ b/apps/studio-host/src/styles/recent-documents-dialog.css
@@ -1,0 +1,54 @@
+.recent-documents-dialog {
+  max-width: calc(100vw - 32px);
+}
+
+.recent-documents-body {
+  padding: 12px 16px;
+}
+
+.recent-documents-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: min(360px, calc(100vh - 220px));
+  overflow: auto;
+}
+
+.recent-documents-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 2px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text);
+  text-align: left;
+  cursor: default;
+}
+
+.recent-documents-item[aria-selected="true"] {
+  border-color: var(--color-primary);
+  background: var(--color-primary-bg);
+}
+
+.recent-documents-name {
+  overflow: hidden;
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.recent-documents-path {
+  overflow: hidden;
+  color: var(--color-text-placeholder);
+  font-size: var(--font-size-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.recent-documents-footer-spacer {
+  flex: 1;
+}

--- a/apps/studio-host/src/ui/home-screen.ts
+++ b/apps/studio-host/src/ui/home-screen.ts
@@ -1,0 +1,339 @@
+import type { DesktopBridgeApi, RecentDocument } from '@/core/tauri-bridge';
+
+type HomeScreenBridge = Partial<Pick<
+  DesktopBridgeApi,
+  'listRecentDocuments' | 'openDocumentByPath' | 'renderDocumentPreview'
+>>;
+const RECENT_DOCUMENTS_PER_PAGE = 5;
+
+interface HomeScreenActions {
+  openFile(): void;
+  createNewDocument(): void;
+  onDocumentLoaded(payload: unknown): void;
+  setMessage(message: string): void;
+}
+
+export class HomeScreen {
+  private root: HTMLElement;
+  private recentSection: HTMLElement;
+  private recentTrack: HTMLElement;
+  private recentHint: HTMLElement;
+  private recentPagination: HTMLElement;
+  private recentPageLabel: HTMLElement;
+  private prevButton: HTMLButtonElement;
+  private nextButton: HTMLButtonElement;
+  private readonly bridge: HomeScreenBridge;
+  private currentPage = 0;
+  private recentDocuments: RecentDocument[] = [];
+
+  constructor(
+    private container: HTMLElement,
+    bridge: unknown,
+    private actions: HomeScreenActions,
+  ) {
+    this.bridge = (bridge && typeof bridge === 'object') ? bridge as HomeScreenBridge : {};
+    this.root = this.build();
+    this.recentSection = this.root.querySelector('.home-recent') as HTMLElement;
+    this.recentTrack = this.root.querySelector('.home-recent-track') as HTMLElement;
+    this.recentHint = this.root.querySelector('.home-recent-hint') as HTMLElement;
+    this.recentPagination = this.root.querySelector('.home-recent-pagination') as HTMLElement;
+    this.recentPageLabel = this.root.querySelector('.home-recent-page-label') as HTMLElement;
+    this.prevButton = this.root.querySelector('.home-recent-page-prev') as HTMLButtonElement;
+    this.nextButton = this.root.querySelector('.home-recent-page-next') as HTMLButtonElement;
+    this.container.appendChild(this.root);
+  }
+
+  async refresh(hasDocument: boolean): Promise<void> {
+    this.root.hidden = hasDocument;
+    this.container.classList.toggle('home-visible', !hasDocument);
+    if (hasDocument) return;
+
+    const recentDocuments = await this.loadRecentDocuments();
+    this.renderRecentDocuments(recentDocuments);
+  }
+
+  private build(): HTMLElement {
+    const root = document.createElement('section');
+    root.className = 'home-screen';
+    root.hidden = true;
+
+    const hero = document.createElement('div');
+    hero.className = 'home-hero';
+
+    const eyebrow = document.createElement('div');
+    eyebrow.className = 'home-eyebrow';
+    eyebrow.textContent = 'Open HWP';
+
+    const title = document.createElement('h1');
+    title.className = 'home-title';
+    title.textContent = '최근에 작업한 문서를 바로 이어서 열어보세요';
+
+    const subtitle = document.createElement('p');
+    subtitle.className = 'home-subtitle';
+    subtitle.textContent = 'HWP/HWPX 문서를 열거나 새 문서를 만들고, 드래그 앤 드롭으로 바로 시작할 수 있습니다.';
+
+    const actions = document.createElement('div');
+    actions.className = 'home-actions';
+
+    actions.append(
+      this.createActionButton('문서 열기', '홈 화면에서 파일 선택', () => {
+        this.actions.openFile();
+      }),
+      this.createActionButton('새 문서', '빈 HWP 문서 만들기', () => {
+        this.actions.createNewDocument();
+      }),
+    );
+
+    hero.append(eyebrow, title, subtitle, actions);
+
+    const recentSection = document.createElement('section');
+    recentSection.className = 'home-recent';
+
+    const recentHeader = document.createElement('div');
+    recentHeader.className = 'home-section-header';
+
+    const recentTitle = document.createElement('h2');
+    recentTitle.className = 'home-section-title';
+    recentTitle.textContent = '최근 문서';
+
+    const recentPagination = document.createElement('div');
+    recentPagination.className = 'home-recent-pagination';
+
+    const prevButton = document.createElement('button');
+    prevButton.type = 'button';
+    prevButton.className = 'home-recent-page-btn home-recent-page-prev';
+    prevButton.textContent = '이전';
+    prevButton.addEventListener('click', () => {
+      this.changePage(-1);
+    });
+
+    const pageLabel = document.createElement('span');
+    pageLabel.className = 'home-recent-page-label';
+
+    const nextButton = document.createElement('button');
+    nextButton.type = 'button';
+    nextButton.className = 'home-recent-page-btn home-recent-page-next';
+    nextButton.textContent = '다음';
+    nextButton.addEventListener('click', () => {
+      this.changePage(1);
+    });
+
+    recentPagination.append(prevButton, pageLabel, nextButton);
+
+    const recentHint = document.createElement('p');
+    recentHint.className = 'home-recent-hint';
+
+    const recentTrack = document.createElement('div');
+    recentTrack.className = 'home-recent-track';
+
+    recentHeader.append(recentTitle, recentPagination);
+    recentSection.append(recentHeader, recentHint, recentTrack);
+
+    const dropHint = document.createElement('div');
+    dropHint.className = 'home-drop-hint';
+    dropHint.textContent = '파일을 이 창으로 끌어다 놓아도 열 수 있습니다.';
+
+    root.append(hero, recentSection, dropHint);
+    return root;
+  }
+
+  private createActionButton(label: string, description: string, action: () => void): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'home-action';
+
+    const title = document.createElement('span');
+    title.className = 'home-action-title';
+    title.textContent = label;
+
+    const subtitle = document.createElement('span');
+    subtitle.className = 'home-action-description';
+    subtitle.textContent = description;
+
+    button.append(title, subtitle);
+    button.addEventListener('click', action);
+    return button;
+  }
+
+  private async loadRecentDocuments(): Promise<RecentDocument[]> {
+    if (!this.bridge.listRecentDocuments) return [];
+    try {
+      return await this.bridge.listRecentDocuments();
+    } catch (error) {
+      console.warn('[home-screen] recent document load failed:', error);
+      return [];
+    }
+  }
+
+  private renderRecentDocuments(documents: RecentDocument[]): void {
+    this.recentDocuments = documents;
+    const totalPages = this.totalPages();
+    this.currentPage = totalPages === 0 ? 0 : Math.min(this.currentPage, totalPages - 1);
+    this.recentTrack.replaceChildren();
+    if (documents.length === 0) {
+      this.recentSection.classList.add('is-empty');
+      this.recentHint.textContent = '아직 최근 문서가 없습니다. 문서를 한 번 열면 여기에 바로 나타납니다.';
+      this.updatePagination();
+      return;
+    }
+
+    this.recentSection.classList.remove('is-empty');
+    this.recentHint.textContent = '앱을 실행하자마자 이어서 작업할 수 있도록 최근에 연 문서를 보여줍니다.';
+
+    const pageStart = this.currentPage * RECENT_DOCUMENTS_PER_PAGE;
+    const pageItems = documents.slice(pageStart, pageStart + RECENT_DOCUMENTS_PER_PAGE);
+    for (const documentInfo of pageItems) {
+      this.recentTrack.appendChild(this.createRecentCard(documentInfo));
+    }
+    for (let index = pageItems.length; index < RECENT_DOCUMENTS_PER_PAGE; index += 1) {
+      this.recentTrack.appendChild(this.createPlaceholderCard());
+    }
+    this.updatePagination();
+  }
+
+  private createRecentCard(documentInfo: RecentDocument): HTMLButtonElement {
+    const card = document.createElement('button');
+    card.type = 'button';
+    card.className = 'home-recent-card';
+
+    const meta = document.createElement('div');
+    meta.className = 'home-recent-meta';
+
+    const fileName = document.createElement('div');
+    fileName.className = 'home-recent-name';
+    fileName.textContent = documentInfo.fileName;
+
+    const filePath = document.createElement('div');
+    filePath.className = 'home-recent-path';
+    filePath.textContent = documentInfo.path;
+
+    meta.append(fileName, filePath);
+
+    const preview = document.createElement('div');
+    preview.className = 'home-recent-preview';
+    preview.append(
+      this.createPreviewLine('home-preview-line is-wide'),
+      this.createPreviewLine('home-preview-line'),
+      this.createPreviewLine('home-preview-line is-short'),
+      this.createPreviewLine('home-preview-line is-wide'),
+      this.createPreviewGrid(),
+    );
+    void this.loadRecentPreview(preview, documentInfo.path);
+
+    card.append(meta, preview);
+    card.addEventListener('click', () => {
+      void this.openRecentDocument(documentInfo);
+    });
+    return card;
+  }
+
+  private createPlaceholderCard(): HTMLElement {
+    const placeholder = document.createElement('div');
+    placeholder.className = 'home-recent-card is-placeholder';
+    placeholder.setAttribute('aria-hidden', 'true');
+    const meta = document.createElement('div');
+    meta.className = 'home-recent-meta';
+    const preview = document.createElement('div');
+    preview.className = 'home-recent-preview';
+    placeholder.append(meta, preview);
+    return placeholder;
+  }
+
+  private async loadRecentPreview(preview: HTMLElement, path: string): Promise<void> {
+    if (!this.bridge.renderDocumentPreview) return;
+
+    try {
+      const svgMarkup = await this.bridge.renderDocumentPreview(path);
+      const svgNode = this.parsePreviewSvg(svgMarkup);
+      if (!svgNode) return;
+
+      preview.replaceChildren(svgNode);
+      preview.classList.add('is-loaded');
+    } catch (error) {
+      console.warn('[home-screen] recent preview render failed:', error);
+    }
+  }
+
+  private parsePreviewSvg(svgMarkup: string): SVGSVGElement | null {
+    const parsed = new DOMParser().parseFromString(svgMarkup, 'image/svg+xml');
+    if (parsed.querySelector('parsererror')) return null;
+
+    const svgElement = parsed.documentElement;
+    if (svgElement.tagName.toLowerCase() !== 'svg') return null;
+
+    svgElement.setAttribute('preserveAspectRatio', 'xMidYMin slice');
+    svgElement.setAttribute('width', '100%');
+    svgElement.setAttribute('height', '100%');
+
+    this.sanitizePreviewSvg(svgElement);
+    return document.importNode(svgElement, true) as unknown as SVGSVGElement;
+  }
+
+  private sanitizePreviewSvg(root: Element): void {
+    root.querySelectorAll('script, foreignObject, iframe, object, embed, link, meta').forEach((node) => {
+      node.remove();
+    });
+
+    const elements = [root, ...Array.from(root.querySelectorAll('*'))];
+    for (const element of elements) {
+      for (const attribute of Array.from(element.attributes)) {
+        const name = attribute.name.toLowerCase();
+        const value = attribute.value.trim().toLowerCase();
+        if (name.startsWith('on') || value.includes('javascript:')) {
+          element.removeAttribute(attribute.name);
+        }
+      }
+    }
+  }
+
+  private createPreviewLine(className: string): HTMLElement {
+    const line = document.createElement('div');
+    line.className = className;
+    return line;
+  }
+
+  private createPreviewGrid(): HTMLElement {
+    const grid = document.createElement('div');
+    grid.className = 'home-preview-grid';
+    for (let index = 0; index < 6; index += 1) {
+      const cell = document.createElement('div');
+      cell.className = 'home-preview-cell';
+      grid.appendChild(cell);
+    }
+    return grid;
+  }
+
+  private async openRecentDocument(documentInfo: RecentDocument): Promise<void> {
+    if (!this.bridge.openDocumentByPath) return;
+
+    try {
+      this.actions.setMessage('파일 로딩 중...');
+      const payload = await this.bridge.openDocumentByPath(documentInfo.path);
+      if (payload) this.actions.onDocumentLoaded(payload);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.actions.setMessage(`파일 로드 실패: ${message}`);
+      console.error('[home-screen] recent document open failed:', error);
+    }
+  }
+
+  private changePage(direction: -1 | 1): void {
+    const nextPage = this.currentPage + direction;
+    if (nextPage < 0 || nextPage >= this.totalPages()) return;
+    this.currentPage = nextPage;
+    this.renderRecentDocuments(this.recentDocuments);
+  }
+
+  private updatePagination(): void {
+    const totalPages = this.totalPages();
+    const hasPages = totalPages > 1;
+    this.recentPagination.hidden = !hasPages;
+    this.recentPageLabel.textContent = totalPages === 0 ? '' : `${this.currentPage + 1} / ${totalPages}`;
+    this.prevButton.disabled = this.currentPage === 0;
+    this.nextButton.disabled = totalPages === 0 || this.currentPage >= totalPages - 1;
+  }
+
+  private totalPages(): number {
+    return Math.ceil(this.recentDocuments.length / RECENT_DOCUMENTS_PER_PAGE);
+  }
+}

--- a/apps/studio-host/src/ui/home-screen.ts
+++ b/apps/studio-host/src/ui/home-screen.ts
@@ -60,10 +60,6 @@ export class HomeScreen {
     const hero = document.createElement('div');
     hero.className = 'home-hero';
 
-    const eyebrow = document.createElement('div');
-    eyebrow.className = 'home-eyebrow';
-    eyebrow.textContent = 'Open HWP';
-
     const title = document.createElement('h1');
     title.className = 'home-title';
     title.textContent = '최근에 작업한 문서를 바로 이어서 열어보세요';
@@ -84,7 +80,7 @@ export class HomeScreen {
       }),
     );
 
-    hero.append(eyebrow, title, subtitle, actions);
+    hero.append(title, subtitle, actions);
 
     const recentSection = document.createElement('section');
     recentSection.className = 'home-recent';

--- a/apps/studio-host/src/ui/recent-documents-dialog.ts
+++ b/apps/studio-host/src/ui/recent-documents-dialog.ts
@@ -1,0 +1,132 @@
+import type { RecentDocument } from '@/core/tauri-bridge';
+
+export function openRecentDocumentsDialog(
+  documents: RecentDocument[],
+  options: {
+    clearRecentDocuments(): Promise<void>;
+  },
+): Promise<RecentDocument | null> {
+  return new Promise((resolve) => {
+    let selectedIndex = 0;
+
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+
+    const dialog = document.createElement('div');
+    dialog.className = 'dialog-wrap recent-documents-dialog';
+    dialog.style.width = '520px';
+
+    const titleBar = document.createElement('div');
+    titleBar.className = 'dialog-title';
+    titleBar.textContent = '최근 문서';
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'dialog-close';
+    closeBtn.textContent = '\u00D7';
+    titleBar.appendChild(closeBtn);
+
+    const body = document.createElement('div');
+    body.className = 'dialog-body recent-documents-body';
+
+    const list = document.createElement('div');
+    list.className = 'recent-documents-list';
+    list.setAttribute('role', 'listbox');
+    body.appendChild(list);
+
+    const footer = document.createElement('div');
+    footer.className = 'dialog-footer';
+
+    const clearBtn = document.createElement('button');
+    clearBtn.className = 'dialog-btn recent-documents-clear';
+    clearBtn.textContent = '목록 비우기';
+
+    const spacer = document.createElement('span');
+    spacer.className = 'recent-documents-footer-spacer';
+
+    const openBtn = document.createElement('button');
+    openBtn.className = 'dialog-btn dialog-btn-primary';
+    openBtn.textContent = '열기';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'dialog-btn';
+    cancelBtn.textContent = '취소';
+
+    footer.append(clearBtn, spacer, openBtn, cancelBtn);
+    dialog.append(titleBar, body, footer);
+    overlay.appendChild(dialog);
+
+    const close = (value: RecentDocument | null) => {
+      document.removeEventListener('keydown', onKeyDown, true);
+      overlay.remove();
+      resolve(value);
+    };
+
+    const renderList = () => {
+      list.replaceChildren();
+      documents.forEach((recentDocument, index) => {
+        const item = document.createElement('button');
+        item.type = 'button';
+        item.className = 'recent-documents-item';
+        item.setAttribute('role', 'option');
+        item.setAttribute('aria-selected', String(index === selectedIndex));
+        item.dataset.index = String(index);
+
+        const name = document.createElement('span');
+        name.className = 'recent-documents-name';
+        name.textContent = recentDocument.fileName;
+
+        const path = document.createElement('span');
+        path.className = 'recent-documents-path';
+        path.textContent = recentDocument.path;
+
+        item.append(name, path);
+        item.addEventListener('click', () => {
+          selectedIndex = index;
+          renderList();
+        });
+        item.addEventListener('dblclick', () => close(documents[index] ?? null));
+        list.appendChild(item);
+      });
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      event.stopPropagation();
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close(null);
+      } else if (event.key === 'Enter') {
+        event.preventDefault();
+        close(documents[selectedIndex] ?? null);
+      } else if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        selectedIndex = Math.min(documents.length - 1, selectedIndex + 1);
+        renderList();
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        selectedIndex = Math.max(0, selectedIndex - 1);
+        renderList();
+      }
+    };
+
+    closeBtn.addEventListener('click', () => close(null));
+    cancelBtn.addEventListener('click', () => close(null));
+    openBtn.addEventListener('click', () => close(documents[selectedIndex] ?? null));
+    clearBtn.addEventListener('click', () => {
+      clearBtn.disabled = true;
+      void options.clearRecentDocuments()
+        .then(() => close(null))
+        .catch((error: unknown) => {
+          console.warn('[recent-documents] clear failed:', error);
+          clearBtn.disabled = false;
+        });
+    });
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) close(null);
+    });
+
+    renderList();
+    document.body.appendChild(overlay);
+    document.addEventListener('keydown', onKeyDown, true);
+    openBtn.focus();
+  });
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hop",
   "version": "0.1.11",
   "private": true,
-  "description": "HOP is Open HWP",
+  "description": "HOP desktop editor for HWP and HWPX documents",
   "license": "MIT",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/site/index.html
+++ b/site/index.html
@@ -3,12 +3,12 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>HOP is Open HWP</title>
+        <title>HOP - HWP/HWPX 문서 편집기</title>
         <meta
             name="description"
             content="HOP는 HWP/HWPX 문서를 보고 편집할 수 있는 오픈소스 데스크톱 앱입니다."
         />
-        <meta property="og:title" content="HOP is Open HWP" />
+        <meta property="og:title" content="HOP - HWP/HWPX 문서 편집기" />
         <meta
             property="og:description"
             content="HWP/HWPX 문서를 보고 편집할 수 있는 오픈소스 데스크톱 앱"
@@ -31,7 +31,7 @@
                         width="48"
                         height="48"
                     />
-                    <span>HOP is Open HWP</span>
+                    <span>HOP</span>
                 </div>
 
                 <div class="intro-grid">


### PR DESCRIPTION
최근에 연 문서를 다시 쉽게 열 수 있도록 최근 문서 기능을 추가했습니다.
파일 메뉴의 최근 문서 목록뿐 아니라, 앱 실행 시 홈 화면에서도 최근 문서를 바로 확인하고 열 수 있게 개선했습니다.

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/d0deae8c-bc72-4ede-a0f3-002eba39a9ea" />
홈 화면에 최근 문서 UX 개선을 하였으며
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/987f5ef6-f1f0-4a04-b30e-b9b697373a65" />
위 이미지와 같이 편집 도중에도 최근 문서 기능을 이용해서 다른 문서를 바로 불러올 수 있습니다.


-최근 문서 저장 기능 추가
-최근 문서 목록 조회 및 비우기 기능 추가
-파일 > 최근 문서 메뉴 추가
-최근 문서 선택 다이얼로그 추가
-앱 실행 시 문서가 없으면 홈 화면에서 최근 문서 표시
-홈 화면 최근 문서에 페이지네이션 적용
-최근 문서 카드에 문서 첫 페이지 프리뷰 표시
-최근 문서 카드 크기가 페이지별/문서 개수별로 달라지지 않도록 레이아웃 조정

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/7e68e15d-f22c-45a6-afb5-d17e29a3afe0" />
(최근 문서가 없는 경우)