### PR TITLE
HWP 문서에서도 비표준 문서 보정 모달 표시

### DIFF
--- a/apps/studio-host/src/main.ts
+++ b/apps/studio-host/src/main.ts
@@ -40,8 +40,6 @@ const wasm = createBridge();
 const eventBus = new EventBus();
 let desktopPlatform = detectDesktopPlatform();
 
-type DocumentSourceFormat = 'hwp' | 'hwpx';
-
 type DirtyAwareBridge = {
   markDocumentDirty?(): void;
   hasUnsavedChanges?(): boolean;
@@ -107,10 +105,6 @@ const sbPage = () => document.getElementById('sb-page')!;
 const sbSection = () => document.getElementById('sb-section')!;
 const sbZoomVal = () => document.getElementById('sb-zoom-val')!;
 const ZOOM_STEP = 0.1;
-
-function currentSourceFormat(): DocumentSourceFormat {
-  return wasm.getSourceFormat() === 'hwpx' ? 'hwpx' : 'hwp';
-}
 
 async function initialize(): Promise<void> {
   const msg = sbMessage();
@@ -534,7 +528,6 @@ function setupEventListeners(): void {
 async function initializeDocument(
   docInfo: DocumentInfo,
   displayName: string,
-  sourceFormat: DocumentSourceFormat = currentSourceFormat(),
 ): Promise<void> {
   const msg = sbMessage();
   try {
@@ -555,15 +548,13 @@ async function initializeDocument(
     inputHandler?.activateWithCaretPosition();
 
     try {
-      if (sourceFormat === 'hwpx') {
-        const report = wasm.getValidationWarnings();
-        if (report.count > 0) {
-          const choice = await showValidationModalIfNeeded(report);
-          if (choice === 'auto-fix') {
-            const reflowedCount = wasm.reflowLinesegs();
-            canvasView?.loadDocument();
-            msg.textContent = `${displayName} (비표준 lineseg ${reflowedCount}건 자동 보정됨)`;
-          }
+      const report = wasm.getValidationWarnings();
+      if (report.count > 0) {
+        const choice = await showValidationModalIfNeeded(report);
+        if (choice === 'auto-fix') {
+          const reflowedCount = wasm.reflowLinesegs();
+          canvasView?.loadDocument();
+          msg.textContent = `${displayName} (비표준 lineseg ${reflowedCount}건 자동 보정됨)`;
         }
       }
     } catch (error) {
@@ -606,7 +597,7 @@ async function createNewDocument(): Promise<void> {
       return;
     }
     const docInfo = wasm.createNewDocument();
-    await initializeDocument(docInfo, `새 문서.hwp — ${docInfo.pageCount}페이지`, 'hwp');
+    await initializeDocument(docInfo, `새 문서.hwp — ${docInfo.pageCount}페이지`);
   } catch (error) {
     msg.textContent = `새 문서 생성 실패: ${error}`;
     console.error('[main] 새 문서 생성 실패:', error);


### PR DESCRIPTION
# 문제점

RHWP에서는 정상적으로 보정 모달이 표시되는 문서가 HOP에서는 표시되지 않고, 보정되지 않은 상태로 렌더링됩니다.

해당 문서는 비표준 lineseg 경고가 있는 HWP 문서로 보이며, upstream rhwp-studio에서는 문서 로드 후 보정 여부를 묻는 모달이 표시됩니다.

## 개요

HOP에서도 비표준 lineseg 경고가 있는 HWP 문서를 열 때 upstream rhwp-studio와 동일하게 보정 모달이 표시되도록 수정했습니다.

기존 HOP 구현에서는 validation warning 확인이 `sourceFormat === 'hwpx'` 조건 안에 있어, HWP 문서에서 경고가 감지되더라도 “자동 보정” 선택지가 나타나지 않았습니다.

이번 변경에서는 해당 조건을 제거해 HWP/HWPX 모두에서 `getValidationWarnings()` 결과를 확인하고, 경고가 있을 경우 기존 보정 모달과 `reflowLinesegs()` 흐름을 사용하도록 했습니다.

## 변경 사항

- HWPX 전용 validation modal guard 제거
- HWP 문서에서도 validation warning이 있으면 보정 모달 표시
- 새 문서 생성 시 불필요해진 `sourceFormat` 전달 제거
- 관련 dead code 정리

## 영향 범위

- `apps/studio-host/src/main.ts`의 문서 초기화 흐름만 변경
- canvas overlay/rendering 관련 maintainer follow-up 커밋과는 변경 영역이 겹치지 않음
- upstream `third_party/rhwp`는 수정하지 않음

## 동작 확인

기존 v0.2.0에서는 해당 HWP 문서가 보정되지 않은 상태로 표시되었고, 이번 변경 후에는 보정 모달이 표시되며 “자동 보정” 선택 시 정상적으로 보정된 렌더링을 확인했습니다.
<img width="1728" height="598" alt="스크린샷 2026-05-15 오후 4 47 55" src="https://github.com/user-attachments/assets/4b3e4878-948c-4f94-a162-5ae4ebd24a52" />

<img width="1728" height="1053" alt="스크린샷 2026-05-15 오후 4 45 08" src="https://github.com/user-attachments/assets/10dfca23-ea34-4615-a643-1b4492679900" />



##
이전에 HWP 문서에서도 보정 기능이 동작하도록 수정한 PR이 있었는데, 이후 `HWPX-only validation modal guard`가 다시 들어오면서 HWP 문서의 보정 모달이 표시되지 않는 상태가 된 것으로 보입니다.

혹시 해당 guard가 의도된 변경이었는지 확인 부탁드립니다. 의도된 변경이 아니라면, HWP 문서에서도 validation warning 기반 보정 모달이 표시되는 현재 동작이 upstream rhwp-studio와 더 일치한다고 판단했습니다.