### PR TITLE
Cmd+C/Cmd+X 단축키가 WebView 클립보드 경로를 타도록 수정

### DIFF
--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -37,12 +37,8 @@ pub fn install(app: &mut App) -> tauri::Result<()> {
     let redo = MenuItemBuilder::with_id("edit:redo", "Redo")
         .accelerator("CmdOrCtrl+Shift+Z")
         .build(app)?;
-    let cut = MenuItemBuilder::with_id("edit:cut", "Cut")
-        .accelerator("CmdOrCtrl+X")
-        .build(app)?;
-    let copy = MenuItemBuilder::with_id("edit:copy", "Copy")
-        .accelerator("CmdOrCtrl+C")
-        .build(app)?;
+    let cut = PredefinedMenuItem::cut(app, Some("Cut"))?;
+    let copy = PredefinedMenuItem::copy(app, Some("Copy"))?;
     let paste = PredefinedMenuItem::paste(app, Some("Paste"))?;
     let find = MenuItemBuilder::with_id("edit:find", "Find")
         .accelerator("CmdOrCtrl+F")

--- a/tests/rhwp-baseline.test.mjs
+++ b/tests/rhwp-baseline.test.mjs
@@ -110,6 +110,16 @@ test('HOP keeps PDF export menu-only without a stale Ctrl+E label', async () => 
   assert.doesNotMatch(pdfMenuItem[0], /md-shortcut|Ctrl\+E|Cmd\+E/);
 });
 
+test('HOP lets native clipboard shortcuts reach the WebView first responder', async () => {
+  const menuSource = await readFile(join(repoRoot, 'apps/desktop/src-tauri/src/menu.rs'), 'utf8');
+
+  assert.match(menuSource, /PredefinedMenuItem::cut\(app,\s*Some\("Cut"\)\)/);
+  assert.match(menuSource, /PredefinedMenuItem::copy\(app,\s*Some\("Copy"\)\)/);
+  assert.match(menuSource, /PredefinedMenuItem::paste\(app,\s*Some\("Paste"\)\)/);
+  assert.doesNotMatch(menuSource, /with_id\("edit:cut"/);
+  assert.doesNotMatch(menuSource, /with_id\("edit:copy"/);
+});
+
 function git(args) {
   const result = spawnSync('git', args, {
     cwd: repoRoot,


### PR DESCRIPTION
## 요약
- 데스크톱 native 메뉴의 Copy/Cut을 Tauri predefined clipboard item으로 변경했습니다.
- Cmd+C/Cmd+X가 앱 커맨드 이벤트로 우회하지 않고 WebView first responder의 표준 클립보드 경로로 전달되도록 했습니다.
- 동일 회귀를 막기 위해 native clipboard 메뉴 항목 유지 테스트를 추가했습니다.

## 원인
기존 Copy/Cut 메뉴가 `MenuItemBuilder::with_id("edit:copy"|"edit:cut")`와 accelerator로 등록되어 있어 macOS에서 Cmd+C/Cmd+X 입력이 WebView의 copy/cut responder로 가지 않고 `hop-menu-command` 이벤트로 우회했습니다. 이 경로에서는 에디터의 표준 clipboard 이벤트 처리가 실행되지 않아 선택 영역 복사/오려두기가 동작하지 않았습니다.

## 검증
- `node --test tests/rhwp-baseline.test.mjs`
- `pnpm run test:upstream`
- `pnpm run test:desktop`
- `pnpm run clippy:desktop`
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check`
- `git diff --check`
- macOS dev 앱에서 선택 영역 생성 후 Cmd+C 복사, Cmd+X 오려두기 수동 확인
