### PR TITLE
fix(studio): prevent blank macOS print pages

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1834,6 +1834,8 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 name = "hop-desktop"
 version = "0.3.1"
 dependencies = [
+ "block2",
+ "objc2",
  "objc2-app-kit",
  "objc2-foundation",
  "objc2-web-kit",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1834,9 +1834,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 name = "hop-desktop"
 version = "0.3.1"
 dependencies = [
- "objc2",
  "objc2-app-kit",
- "objc2-core-graphics",
  "objc2-foundation",
  "objc2-web-kit",
  "open",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1834,8 +1834,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 name = "hop-desktop"
 version = "0.3.1"
 dependencies = [
+ "objc2",
  "objc2-app-kit",
+ "objc2-core-graphics",
  "objc2-foundation",
+ "objc2-web-kit",
  "open",
  "pdf-writer",
  "rhwp",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -36,5 +36,8 @@ usvg = "0.45"
 pdf-writer = "0.12"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSDocumentController"] }
-objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSURL"] }
+objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSDocumentController", "NSPrintInfo", "NSPrintOperation", "NSPrinter"] }
+objc2-core-graphics = { version = "0.3.2", default-features = false, features = ["std", "CGBitmapContext", "CGColorSpace", "CGContext", "CGDataProvider", "CGImage", "CGPDFDocument", "CGPDFPage"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSDictionary", "NSGeometry", "NSObject", "NSString", "NSURL"] }
+objc2-web-kit = { version = "0.3.2", default-features = false, features = ["std", "objc2-app-kit", "WKWebView"] }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -36,8 +36,6 @@ usvg = "0.45"
 pdf-writer = "0.12"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2 = "0.6.4"
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSDocumentController", "NSPrintInfo", "NSPrintOperation", "NSPrinter"] }
-objc2-core-graphics = { version = "0.3.2", default-features = false, features = ["std", "CGBitmapContext", "CGColorSpace", "CGContext", "CGDataProvider", "CGImage", "CGPDFDocument", "CGPDFPage"] }
-objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSDictionary", "NSGeometry", "NSObject", "NSString", "NSURL"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSGeometry", "NSThread", "NSURL"] }
 objc2-web-kit = { version = "0.3.2", default-features = false, features = ["std", "objc2-app-kit", "WKWebView"] }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -36,6 +36,8 @@ usvg = "0.45"
 pdf-writer = "0.12"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSDocumentController", "NSPrintInfo", "NSPrintOperation", "NSPrinter"] }
-objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSGeometry", "NSThread", "NSURL"] }
+block2 = "0.6.2"
+objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSApplication", "NSDocumentController", "NSPrintInfo", "NSPrintOperation", "NSPrinter", "NSView"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "block2", "NSDate", "NSGeometry", "NSRunLoop", "NSThread", "NSTimer", "NSURL"] }
 objc2-web-kit = { version = "0.3.2", default-features = false, features = ["std", "objc2-app-kit", "WKWebView"] }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1,4 +1,5 @@
 use crate::font_catalog::LocalFontEntry;
+use crate::print_probe::PrintProbeInput;
 use crate::recent_documents::{self, RecentDocument};
 use crate::state::{
     editable_core_from_bytes, AppState, DocumentFormat, DocumentOpenResult,
@@ -306,7 +307,24 @@ pub fn reveal_in_folder(path: String) -> Result<(), String> {
 
 #[cfg(all(target_os = "macos", debug_assertions))]
 #[tauri::command]
-pub fn print_webview(window: WebviewWindow) -> Result<(), String> {
+pub fn print_webview(
+    window: WebviewWindow,
+    probe_input: Option<PrintProbeInput>,
+) -> Result<(), String> {
+    if let Some(observation_path) = crate::print_probe::configured_geometry_probe_path()? {
+        let input = probe_input
+            .ok_or_else(|| "print geometry probe requires sanitized frontend input".to_string())?;
+        crate::print_probe::write_probe_stage(
+            &observation_path,
+            crate::print_probe::ProbeStage::NativePrintEntered,
+        )?;
+        crate::macos_print_geometry_probe::observe_attached_webview_geometry(
+            &window,
+            observation_path,
+            input,
+        )?;
+        return Ok(());
+    }
     if let Some(observation_path) = crate::macos_print_capture::configured_observation_path()? {
         crate::macos_print_capture::observe_attached_webview(&window, observation_path)?;
         return Ok(());
@@ -319,10 +337,18 @@ pub fn print_webview(window: WebviewWindow) -> Result<(), String> {
 
 #[cfg(not(all(target_os = "macos", debug_assertions)))]
 #[tauri::command]
-pub fn print_webview(window: WebviewWindow) -> Result<(), String> {
+pub fn print_webview(
+    window: WebviewWindow,
+    _probe_input: Option<PrintProbeInput>,
+) -> Result<(), String> {
     window
         .print()
         .map_err(|e| format!("인쇄 대화상자를 열 수 없습니다: {}", e))
+}
+
+#[tauri::command]
+pub fn print_geometry_probe_configured() -> Result<bool, String> {
+    crate::print_probe::geometry_probe_configured()
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -306,9 +306,9 @@ pub fn reveal_in_folder(path: String) -> Result<(), String> {
 
 #[cfg(all(target_os = "macos", debug_assertions))]
 #[tauri::command]
-pub async fn print_webview(window: WebviewWindow) -> Result<(), String> {
-    if let Some(capture_path) = crate::macos_print_capture::configured_capture_path()? {
-        crate::macos_print_capture::capture_attached_webview(&window, capture_path).await?;
+pub fn print_webview(window: WebviewWindow) -> Result<(), String> {
+    if let Some(observation_path) = crate::macos_print_capture::configured_observation_path()? {
+        crate::macos_print_capture::observe_attached_webview(&window, observation_path)?;
         return Ok(());
     }
 

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -304,6 +304,20 @@ pub fn reveal_in_folder(path: String) -> Result<(), String> {
     open::that(reveal_path).map_err(|e| format!("파일 위치를 열 수 없습니다: {}", e))
 }
 
+#[cfg(all(target_os = "macos", debug_assertions))]
+#[tauri::command]
+pub async fn print_webview(window: WebviewWindow) -> Result<(), String> {
+    if let Some(capture_path) = crate::macos_print_capture::configured_capture_path()? {
+        crate::macos_print_capture::capture_attached_webview(&window, capture_path).await?;
+        return Ok(());
+    }
+
+    window
+        .print()
+        .map_err(|e| format!("인쇄 대화상자를 열 수 없습니다: {}", e))
+}
+
+#[cfg(not(all(target_os = "macos", debug_assertions)))]
 #[tauri::command]
 pub fn print_webview(window: WebviewWindow) -> Result<(), String> {
     window

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3,6 +3,8 @@ mod commands;
 mod font_catalog;
 #[cfg(target_os = "linux")]
 mod linux_runtime;
+#[cfg(all(target_os = "macos", debug_assertions))]
+mod macos_print_capture;
 #[cfg(target_os = "macos")]
 mod macos_recent_documents;
 #[cfg(target_os = "macos")]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -5,6 +5,8 @@ mod font_catalog;
 mod linux_runtime;
 #[cfg(all(target_os = "macos", debug_assertions))]
 mod macos_print_capture;
+#[cfg(all(target_os = "macos", debug_assertions))]
+mod macos_print_geometry_probe;
 #[cfg(target_os = "macos")]
 mod macos_recent_documents;
 #[cfg(target_os = "macos")]
@@ -12,6 +14,7 @@ mod menu;
 mod pdf_export;
 mod pdf_font_fallbacks;
 mod pending_open;
+mod print_probe;
 mod recent_documents;
 mod state;
 #[cfg(any(target_os = "macos", windows, target_os = "linux"))]
@@ -30,9 +33,9 @@ use commands::{
     destroy_current_window, export_pdf, export_pdf_from_hwp_path, list_local_fonts,
     list_recent_documents, mark_document_dirty, mutate_document, note_finder_recent_document,
     open_document_tracking, prepare_document_open, prepare_staged_hwp_pdf_export,
-    prepare_staged_hwp_save, print_webview, query_document, read_local_font,
-    record_recent_document, render_document_preview, render_page_svg, reveal_in_folder,
-    take_pending_open_paths,
+    prepare_staged_hwp_save, print_geometry_probe_configured, print_webview, query_document,
+    read_local_font, record_recent_document, render_document_preview, render_page_svg,
+    reveal_in_folder, take_pending_open_paths,
 };
 use state::AppState;
 use updates::{get_update_state, restart_to_apply_update, start_update_install};
@@ -91,6 +94,7 @@ pub fn run() {
             export_pdf,
             export_pdf_from_hwp_path,
             print_webview,
+            print_geometry_probe_configured,
             destroy_current_window,
             cancel_app_quit,
             desktop_platform,

--- a/apps/desktop/src-tauri/src/macos_print_capture.rs
+++ b/apps/desktop/src-tauri/src/macos_print_capture.rs
@@ -1,21 +1,14 @@
-use objc2::runtime::ProtocolObject;
-use objc2_app_kit::{
-    NSPaperOrientation, NSPrintInfo, NSPrintJobSavingURL, NSPrintSaveJob, NSPrintingPaginationMode,
-};
-use objc2_core_graphics::{
-    CGBitmapContextCreate, CGColorSpace, CGContext, CGDataProvider, CGImageAlphaInfo,
-    CGImageByteOrderInfo, CGPDFBox, CGPDFDocument, CGPDFPage,
-};
-use objc2_foundation::{NSCopying, NSPoint, NSRect, NSSize, NSString, NSURL};
+use objc2_app_kit::{NSPaperOrientation, NSPrintInfo, NSPrintingPaginationMode};
+use objc2_foundation::{NSCopying, NSRange, NSRect, NSThread};
 use objc2_web_kit::WKWebView;
 use serde::Serialize;
-use std::ffi::{c_void, CString, OsString};
+use std::ffi::{c_void, OsString};
+use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc;
+use std::sync::{Arc, OnceLock};
 use tauri::WebviewWindow;
 
-const CAPTURE_ENV: &str = "HOP_PRINT_CAPTURE_PATH";
-const RASTER_SIZE: usize = 256;
+const OBSERVATION_ENV: &str = "HOP_PRINT_OBSERVATION_PATH";
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -57,147 +50,179 @@ pub(crate) struct PrintInfoSnapshot {
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct PdfPageInspection {
-    pub media_box: RectSnapshot,
-    pub is_visually_blank: bool,
-    pub non_white_pixel_count: usize,
+struct FinitePageRange {
+    location: usize,
+    length: usize,
+    page_count: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct PdfInspection {
-    pub page_count: usize,
-    pub pages: Vec<PdfPageInspection>,
+struct PrintObservation {
+    schema_version: u32,
+    mode: &'static str,
+    run_operation_succeeded: bool,
+    operation_outcome: &'static str,
+    protocol_requires: &'static str,
+    range_location: usize,
+    range_length: usize,
+    page_count: usize,
+    print_info: PrintInfoSnapshot,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct PrintCaptureResult {
-    pub operation_succeeded: bool,
-    pub pdf_path: String,
-    pub metadata_path: String,
-    pub print_info: PrintInfoSnapshot,
-    pub pdf: PdfInspection,
+pub(crate) fn configured_observation_path() -> Result<Option<PathBuf>, String> {
+    observation_path_from_value(std::env::var_os(OBSERVATION_ENV))
 }
 
-pub(crate) fn configured_capture_path() -> Result<Option<PathBuf>, String> {
-    capture_path_from_value(std::env::var_os(CAPTURE_ENV))
-}
-
-fn capture_path_from_value(value: Option<OsString>) -> Result<Option<PathBuf>, String> {
+fn observation_path_from_value(value: Option<OsString>) -> Result<Option<PathBuf>, String> {
     let Some(value) = value else {
         return Ok(None);
     };
     let path = PathBuf::from(value);
     if !path.is_absolute() {
-        return Err(format!("{CAPTURE_ENV} must be an absolute path"));
+        return Err(format!("{OBSERVATION_ENV} must be an absolute path"));
     }
     if path
         .extension()
         .and_then(|extension| extension.to_str())
-        .is_none_or(|extension| !extension.eq_ignore_ascii_case("pdf"))
+        .is_none_or(|extension| !extension.eq_ignore_ascii_case("json"))
     {
-        return Err(format!("{CAPTURE_ENV} must use a .pdf extension"));
-    }
-    if path.to_str().is_none() {
-        return Err(format!("{CAPTURE_ENV} must be valid UTF-8"));
+        return Err(format!("{OBSERVATION_ENV} must use a .json extension"));
     }
     let parent = path
         .parent()
-        .ok_or_else(|| format!("{CAPTURE_ENV} must have a parent directory"))?;
+        .ok_or_else(|| format!("{OBSERVATION_ENV} must have a parent directory"))?;
     if !parent.is_dir() {
-        return Err(format!("{CAPTURE_ENV} parent directory does not exist"));
+        return Err(format!("{OBSERVATION_ENV} parent directory does not exist"));
     }
     if path.exists() {
-        return Err(format!("{CAPTURE_ENV} destination already exists"));
-    }
-    let metadata_path = metadata_path_for(&path);
-    if metadata_path.exists() {
-        return Err(format!("{CAPTURE_ENV} metadata destination already exists"));
+        return Err(format!("{OBSERVATION_ENV} destination already exists"));
     }
     Ok(Some(path))
 }
 
-fn metadata_path_for(pdf_path: &Path) -> PathBuf {
-    pdf_path.with_extension("pdf.json")
+fn finite_page_range(range: NSRange) -> Result<FinitePageRange, String> {
+    let ns_integer_max = isize::MAX as usize;
+    if range.location == 0 {
+        return Err("print observation page range location must be one-based".to_string());
+    }
+    if range.location >= ns_integer_max {
+        return Err(
+            "print observation page range location must be below NSNotFound/NSIntegerMax"
+                .to_string(),
+        );
+    }
+    if range.length == 0 {
+        return Err("print observation page range has zero pages".to_string());
+    }
+    if range.length == ns_integer_max {
+        return Err("print observation page range is unknown (NSIntegerMax)".to_string());
+    }
+    let last_page = range
+        .location
+        .checked_add(range.length - 1)
+        .ok_or_else(|| "print observation page range overflow".to_string())?;
+    if last_page > ns_integer_max {
+        return Err("print observation last page exceeds NSIntegerMax".to_string());
+    }
+    Ok(FinitePageRange {
+        location: range.location,
+        length: range.length,
+        page_count: range.length,
+    })
 }
 
-pub(crate) async fn capture_attached_webview(
+fn operation_observation(
+    operation_succeeded: bool,
+    range: NSRange,
+    print_info: PrintInfoSnapshot,
+) -> Result<PrintObservation, String> {
+    if operation_succeeded {
+        return Err("Cancel-only print observation was approved instead of cancelled".to_string());
+    }
+    let range = finite_page_range(range)?;
+    Ok(PrintObservation {
+        schema_version: 1,
+        mode: "attached-wkwebview-modal-cancel",
+        run_operation_succeeded: false,
+        operation_outcome: "cancel-or-error",
+        protocol_requires: "human-cancel-attestation",
+        range_location: range.location,
+        range_length: range.length,
+        page_count: range.page_count,
+        print_info,
+    })
+}
+
+pub(crate) fn observe_attached_webview(
     window: &WebviewWindow,
-    pdf_path: PathBuf,
-) -> Result<PrintCaptureResult, String> {
-    let (sender, receiver) = mpsc::sync_channel(1);
+    observation_path: PathBuf,
+) -> Result<(), String> {
+    if !NSThread::isMainThread_class() {
+        return Err("print observation must start on the macOS main thread".to_string());
+    }
+
+    // Tauri 2.10.3 handles WithWebview inline when called from its macOS main
+    // thread. OnceLock propagates the synchronous modal result without sending
+    // the main-thread-only NSPrintOperation to another thread.
+    let outcome = Arc::new(OnceLock::new());
+    let callback_outcome = Arc::clone(&outcome);
     window
         .with_webview(move |platform_webview| {
-            let result = unsafe { capture_webview(platform_webview.inner(), &pdf_path) };
-            let _ = sender.send(result);
+            let result =
+                unsafe { observe_webview(platform_webview.inner(), observation_path.as_path()) };
+            let _ = callback_outcome.set(result);
         })
         .map_err(|error| format!("could not access attached webview: {error}"))?;
 
-    tauri::async_runtime::spawn_blocking(move || {
-        receiver
-            .recv()
-            .map_err(|_| "attached webview print capture ended without a result".to_string())?
-    })
-    .await
-    .map_err(|error| format!("print capture worker failed: {error}"))?
+    Arc::try_unwrap(outcome)
+        .map_err(|_| "attached webview observation did not execute synchronously".to_string())?
+        .into_inner()
+        .ok_or_else(|| "attached webview observation returned no result".to_string())?
 }
 
-unsafe fn capture_webview(
-    webview_pointer: *mut c_void,
-    pdf_path: &Path,
-) -> Result<PrintCaptureResult, String> {
+unsafe fn observe_webview(webview_pointer: *mut c_void, path: &Path) -> Result<(), String> {
     let webview = webview_pointer
         .cast::<WKWebView>()
         .as_ref()
         .ok_or_else(|| "attached WKWebView pointer was null".to_string())?;
 
-    // Copy shared state so the diagnostic preserves printer/paper/scaling without
-    // mutating the process-global print settings. The four margin writes mirror
-    // wry 0.54.4 PrintOptions::default() exactly.
+    // Preserve the live printer/paper/scaling state without mutating the shared
+    // object. The four zero margins and separate-thread permission mirror wry
+    // 0.54.4's normal macOS print inputs.
     let print_info = NSPrintInfo::sharedPrintInfo().copy();
     print_info.setTopMargin(0.0);
     print_info.setRightMargin(0.0);
     print_info.setBottomMargin(0.0);
     print_info.setLeftMargin(0.0);
-    print_info.setJobDisposition(NSPrintSaveJob);
 
-    let path_string = NSString::from_str(
-        pdf_path
-            .to_str()
-            .ok_or_else(|| "capture path must be valid UTF-8".to_string())?,
-    );
-    let output_url = NSURL::fileURLWithPath(&path_string);
-    let print_dictionary = print_info.dictionary();
-    print_dictionary.setObject_forKey(&output_url, ProtocolObject::from_ref(NSPrintJobSavingURL));
-
-    let snapshot = snapshot_print_info(&print_info);
     let operation = webview.printOperationWithPrintInfo(&print_info);
     operation.setCanSpawnSeparateThread(true);
-    operation.setShowsPrintPanel(false);
+    operation.setShowsPrintPanel(true);
     operation.setShowsProgressPanel(false);
-    let operation_succeeded = operation.runOperation();
-    if !operation_succeeded {
-        return Err("attached WKWebView print operation failed".to_string());
-    }
-    if !pdf_path.is_file() {
-        return Err("print operation completed without creating a PDF".to_string());
-    }
 
-    let pdf = inspect_pdf(pdf_path)?;
-    let metadata_path = metadata_path_for(pdf_path);
-    let result = PrintCaptureResult {
+    let operation_succeeded = operation.runOperation();
+    if operation_succeeded {
+        return Err("Cancel-only print observation was approved instead of cancelled".to_string());
+    }
+    let page_range = operation.pageRange();
+    let effective_print_info = operation.printInfo();
+    let observation = operation_observation(
         operation_succeeded,
-        pdf_path: pdf_path.display().to_string(),
-        metadata_path: metadata_path.display().to_string(),
-        print_info: snapshot,
-        pdf,
-    };
-    let metadata = serde_json::to_vec_pretty(&result)
-        .map_err(|error| format!("could not serialize print capture metadata: {error}"))?;
-    std::fs::write(&metadata_path, metadata)
-        .map_err(|error| format!("could not write print capture metadata: {error}"))?;
-    Ok(result)
+        page_range,
+        snapshot_print_info(&effective_print_info),
+    )?;
+    write_observation(path, &observation)
+}
+
+fn write_observation(path: &Path, observation: &PrintObservation) -> Result<(), String> {
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| format!("could not create print observation JSON: {error}"))?;
+    serde_json::to_writer_pretty(file, observation)
+        .map_err(|error| format!("could not write print observation JSON: {error}"))
 }
 
 fn snapshot_print_info(print_info: &NSPrintInfo) -> PrintInfoSnapshot {
@@ -231,68 +256,6 @@ fn pagination_value(value: NSPrintingPaginationMode) -> i64 {
     value.0 as i64
 }
 
-fn inspect_pdf(path: &Path) -> Result<PdfInspection, String> {
-    use std::os::unix::ffi::OsStrExt;
-
-    let filename = CString::new(path.as_os_str().as_bytes())
-        .map_err(|_| "could not open PDF: path contains a NUL byte".to_string())?;
-    let provider = unsafe { CGDataProvider::with_filename(filename.as_ptr()) }
-        .ok_or_else(|| "could not open PDF data provider".to_string())?;
-    let document = CGPDFDocument::with_provider(Some(&provider))
-        .ok_or_else(|| "could not open PDF document".to_string())?;
-    let page_count = CGPDFDocument::number_of_pages(Some(&document));
-    if page_count == 0 {
-        return Err("could not open PDF document with at least one page".to_string());
-    }
-
-    let mut pages = Vec::with_capacity(page_count);
-    for page_number in 1..=page_count {
-        let page = CGPDFDocument::page(Some(&document), page_number)
-            .ok_or_else(|| format!("could not open PDF page {page_number}"))?;
-        let media_box = CGPDFPage::box_rect(Some(&page), CGPDFBox::MediaBox);
-        let non_white_pixel_count = count_non_white_pixels(&page)?;
-        pages.push(PdfPageInspection {
-            media_box: rect_snapshot(media_box),
-            is_visually_blank: non_white_pixel_count == 0,
-            non_white_pixel_count,
-        });
-    }
-    Ok(PdfInspection { page_count, pages })
-}
-
-fn count_non_white_pixels(page: &CGPDFPage) -> Result<usize, String> {
-    let mut pixels = vec![255_u8; RASTER_SIZE * RASTER_SIZE * 4];
-    let color_space = CGColorSpace::new_device_rgb()
-        .ok_or_else(|| "could not create PDF inspection color space".to_string())?;
-    let bitmap_info = CGImageAlphaInfo::PremultipliedLast.0 | CGImageByteOrderInfo::Order32Big.0;
-    let context = unsafe {
-        CGBitmapContextCreate(
-            pixels.as_mut_ptr().cast(),
-            RASTER_SIZE,
-            RASTER_SIZE,
-            8,
-            RASTER_SIZE * 4,
-            Some(&color_space),
-            bitmap_info,
-        )
-    }
-    .ok_or_else(|| "could not create PDF inspection bitmap".to_string())?;
-    let target = NSRect::new(
-        NSPoint::new(0.0, 0.0),
-        NSSize::new(RASTER_SIZE as f64, RASTER_SIZE as f64),
-    );
-    let transform = CGPDFPage::drawing_transform(Some(page), CGPDFBox::MediaBox, target, 0, true);
-    CGContext::concat_ctm(Some(&context), transform);
-    CGContext::draw_pdf_page(Some(&context), Some(page));
-    CGContext::flush(Some(&context));
-    drop(context);
-
-    Ok(pixels
-        .chunks_exact(4)
-        .filter(|pixel| pixel[0] < 250 || pixel[1] < 250 || pixel[2] < 250)
-        .count())
-}
-
 fn rect_snapshot(rect: NSRect) -> RectSnapshot {
     RectSnapshot {
         x: rect.origin.x,
@@ -305,95 +268,153 @@ fn rect_snapshot(rect: NSRect) -> RectSnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pdf_writer::{Content, Finish, Pdf, Rect, Ref};
+    use objc2_foundation::NSRange;
     use std::ffi::OsString;
 
-    fn two_page_fixture() -> Vec<u8> {
-        let mut pdf = Pdf::new();
-        let catalog = Ref::new(1);
-        let pages = Ref::new(2);
-        let first_page = Ref::new(3);
-        let first_content = Ref::new(4);
-        let second_page = Ref::new(5);
-
-        pdf.catalog(catalog).pages(pages);
-        pdf.pages(pages).kids([first_page, second_page]).count(2);
-
-        let mut page = pdf.page(first_page);
-        page.media_box(Rect::new(0.0, 0.0, 595.0, 842.0));
-        page.parent(pages);
-        page.contents(first_content);
-        page.finish();
-
-        let mut content = Content::new();
-        content.rect(100.0, 100.0, 200.0, 200.0);
-        content.fill_nonzero();
-        pdf.stream(first_content, &content.finish());
-
-        let mut page = pdf.page(second_page);
-        page.media_box(Rect::new(0.0, 0.0, 595.0, 842.0));
-        page.parent(pages);
-        page.finish();
-
-        pdf.finish()
+    fn print_info_fixture() -> PrintInfoSnapshot {
+        PrintInfoSnapshot {
+            paper_size: SizeSnapshot {
+                width: 595.0,
+                height: 842.0,
+            },
+            imageable_page_bounds: RectSnapshot {
+                x: 18.0,
+                y: 41.0,
+                width: 559.0,
+                height: 783.0,
+            },
+            margins: MarginsSnapshot {
+                top: 0.0,
+                right: 0.0,
+                bottom: 0.0,
+                left: 0.0,
+            },
+            scaling_factor: 1.0,
+            paper_name: Some("iso-a4".to_string()),
+            orientation: 0,
+            horizontal_pagination: 0,
+            vertical_pagination: 0,
+        }
     }
 
     #[test]
-    fn capture_path_is_disabled_when_environment_value_is_absent() {
-        assert_eq!(capture_path_from_value(None).unwrap(), None);
+    fn observation_path_is_disabled_when_environment_value_is_absent() {
+        assert_eq!(observation_path_from_value(None).unwrap(), None);
     }
 
     #[test]
-    fn capture_path_accepts_a_new_absolute_pdf_in_an_existing_directory() {
+    fn observation_path_accepts_a_new_absolute_json_in_an_existing_directory() {
         let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("capture.pdf");
+        let path = directory.path().join("observation.json");
 
         assert_eq!(
-            capture_path_from_value(Some(path.as_os_str().to_owned())).unwrap(),
+            observation_path_from_value(Some(path.as_os_str().to_owned())).unwrap(),
             Some(path)
         );
     }
 
     #[test]
-    fn capture_path_rejects_relative_non_pdf_and_existing_destinations() {
-        assert!(capture_path_from_value(Some(OsString::from("capture.pdf")))
-            .unwrap_err()
-            .contains("absolute"));
+    fn observation_path_rejects_relative_non_json_and_existing_destinations() {
+        assert!(
+            observation_path_from_value(Some(OsString::from("observation.json")))
+                .unwrap_err()
+                .contains("absolute")
+        );
 
         let directory = tempfile::tempdir().unwrap();
-        let non_pdf = directory.path().join("capture.json");
-        assert!(capture_path_from_value(Some(non_pdf.into_os_string()))
+        let non_json = directory.path().join("observation.pdf");
+        assert!(observation_path_from_value(Some(non_json.into_os_string()))
             .unwrap_err()
-            .contains(".pdf"));
+            .contains(".json"));
 
-        let existing = directory.path().join("capture.pdf");
+        let existing = directory.path().join("observation.json");
         std::fs::write(&existing, b"do not overwrite").unwrap();
-        assert!(capture_path_from_value(Some(existing.into_os_string()))
+        assert!(observation_path_from_value(Some(existing.into_os_string()))
             .unwrap_err()
             .contains("already exists"));
     }
 
     #[test]
-    fn inspect_pdf_reports_page_geometry_and_visual_blankness() {
+    fn observation_path_rejects_a_missing_parent_directory() {
         let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("fixture.pdf");
-        std::fs::write(&path, two_page_fixture()).unwrap();
+        let path = directory.path().join("missing/observation.json");
 
-        let inspection = inspect_pdf(&path).unwrap();
-
-        assert_eq!(inspection.page_count, 2);
-        assert_eq!(inspection.pages.len(), 2);
-        assert_eq!(inspection.pages[0].media_box.width, 595.0);
-        assert_eq!(inspection.pages[0].media_box.height, 842.0);
-        assert!(!inspection.pages[0].is_visually_blank);
-        assert!(inspection.pages[1].is_visually_blank);
+        assert!(observation_path_from_value(Some(path.into_os_string()))
+            .unwrap_err()
+            .contains("parent directory"));
     }
 
     #[test]
-    fn inspect_pdf_rejects_invalid_input() {
-        let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("missing.pdf");
+    fn finite_page_range_preserves_location_and_uses_length_as_page_count() {
+        let range = finite_page_range(NSRange::new(3, 2)).unwrap();
 
-        assert!(inspect_pdf(&path).unwrap_err().contains("open PDF"));
+        assert_eq!(range.location, 3);
+        assert_eq!(range.length, 2);
+        assert_eq!(range.page_count, 2);
+    }
+
+    #[test]
+    fn finite_page_range_accepts_a_last_page_at_ns_integer_max() {
+        let ns_integer_max = isize::MAX as usize;
+        let range = finite_page_range(NSRange::new(ns_integer_max - 1, 2)).unwrap();
+
+        assert_eq!(range.location, ns_integer_max - 1);
+        assert_eq!(range.length, 2);
+        assert_eq!(range.page_count, 2);
+    }
+
+    #[test]
+    fn finite_page_range_rejects_zero_unknown_not_found_and_overflowing_ranges() {
+        let ns_integer_max = isize::MAX as usize;
+
+        assert!(finite_page_range(NSRange::new(1, 0))
+            .unwrap_err()
+            .contains("zero"));
+        assert!(finite_page_range(NSRange::new(1, ns_integer_max))
+            .unwrap_err()
+            .contains("unknown"));
+        assert!(finite_page_range(NSRange::new(ns_integer_max, 1))
+            .unwrap_err()
+            .contains("location"));
+        assert!(finite_page_range(NSRange::new(ns_integer_max + 1, 1))
+            .unwrap_err()
+            .contains("location"));
+        assert!(finite_page_range(NSRange::new(ns_integer_max - 1, 3))
+            .unwrap_err()
+            .contains("NSIntegerMax"));
+        assert!(
+            finite_page_range(NSRange::new(ns_integer_max - 1, usize::MAX))
+                .unwrap_err()
+                .contains("overflow")
+        );
+    }
+
+    #[test]
+    fn operation_observation_rejects_successful_operations() {
+        assert!(
+            operation_observation(true, NSRange::new(1, 2), print_info_fixture(),)
+                .unwrap_err()
+                .contains("Cancel")
+        );
+    }
+
+    #[test]
+    fn operation_observation_serializes_ambiguous_outcome_without_claiming_cancel() {
+        let observation =
+            operation_observation(false, NSRange::new(1, 2), print_info_fixture()).unwrap();
+        let json = serde_json::to_value(observation).unwrap();
+
+        assert_eq!(json["schemaVersion"], 1);
+        assert_eq!(json["mode"], "attached-wkwebview-modal-cancel");
+        assert_eq!(json["runOperationSucceeded"], false);
+        assert_eq!(json["operationOutcome"], "cancel-or-error");
+        assert_eq!(json["protocolRequires"], "human-cancel-attestation");
+        assert!(json.get("operatorAction").is_none());
+        assert_eq!(json["rangeLocation"], 1);
+        assert_eq!(json["rangeLength"], 2);
+        assert_eq!(json["pageCount"], 2);
+        assert_eq!(json["printInfo"]["paperSize"]["width"], 595.0);
+        assert!(json.get("pdfPath").is_none());
+        assert!(json.get("documentPath").is_none());
     }
 }

--- a/apps/desktop/src-tauri/src/macos_print_capture.rs
+++ b/apps/desktop/src-tauri/src/macos_print_capture.rs
@@ -225,7 +225,7 @@ fn write_observation(path: &Path, observation: &PrintObservation) -> Result<(), 
         .map_err(|error| format!("could not write print observation JSON: {error}"))
 }
 
-fn snapshot_print_info(print_info: &NSPrintInfo) -> PrintInfoSnapshot {
+pub(crate) fn snapshot_print_info(print_info: &NSPrintInfo) -> PrintInfoSnapshot {
     let paper_size = print_info.paperSize();
     let imageable = print_info.imageablePageBounds();
     PrintInfoSnapshot {
@@ -256,7 +256,7 @@ fn pagination_value(value: NSPrintingPaginationMode) -> i64 {
     value.0 as i64
 }
 
-fn rect_snapshot(rect: NSRect) -> RectSnapshot {
+pub(crate) fn rect_snapshot(rect: NSRect) -> RectSnapshot {
     RectSnapshot {
         x: rect.origin.x,
         y: rect.origin.y,

--- a/apps/desktop/src-tauri/src/macos_print_capture.rs
+++ b/apps/desktop/src-tauri/src/macos_print_capture.rs
@@ -1,0 +1,399 @@
+use objc2::runtime::ProtocolObject;
+use objc2_app_kit::{
+    NSPaperOrientation, NSPrintInfo, NSPrintJobSavingURL, NSPrintSaveJob, NSPrintingPaginationMode,
+};
+use objc2_core_graphics::{
+    CGBitmapContextCreate, CGColorSpace, CGContext, CGDataProvider, CGImageAlphaInfo,
+    CGImageByteOrderInfo, CGPDFBox, CGPDFDocument, CGPDFPage,
+};
+use objc2_foundation::{NSCopying, NSPoint, NSRect, NSSize, NSString, NSURL};
+use objc2_web_kit::WKWebView;
+use serde::Serialize;
+use std::ffi::{c_void, CString, OsString};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use tauri::WebviewWindow;
+
+const CAPTURE_ENV: &str = "HOP_PRINT_CAPTURE_PATH";
+const RASTER_SIZE: usize = 256;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RectSnapshot {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SizeSnapshot {
+    pub width: f64,
+    pub height: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MarginsSnapshot {
+    pub top: f64,
+    pub right: f64,
+    pub bottom: f64,
+    pub left: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PrintInfoSnapshot {
+    pub paper_size: SizeSnapshot,
+    pub imageable_page_bounds: RectSnapshot,
+    pub margins: MarginsSnapshot,
+    pub scaling_factor: f64,
+    pub paper_name: Option<String>,
+    pub orientation: i64,
+    pub horizontal_pagination: i64,
+    pub vertical_pagination: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PdfPageInspection {
+    pub media_box: RectSnapshot,
+    pub is_visually_blank: bool,
+    pub non_white_pixel_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PdfInspection {
+    pub page_count: usize,
+    pub pages: Vec<PdfPageInspection>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PrintCaptureResult {
+    pub operation_succeeded: bool,
+    pub pdf_path: String,
+    pub metadata_path: String,
+    pub print_info: PrintInfoSnapshot,
+    pub pdf: PdfInspection,
+}
+
+pub(crate) fn configured_capture_path() -> Result<Option<PathBuf>, String> {
+    capture_path_from_value(std::env::var_os(CAPTURE_ENV))
+}
+
+fn capture_path_from_value(value: Option<OsString>) -> Result<Option<PathBuf>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let path = PathBuf::from(value);
+    if !path.is_absolute() {
+        return Err(format!("{CAPTURE_ENV} must be an absolute path"));
+    }
+    if path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_none_or(|extension| !extension.eq_ignore_ascii_case("pdf"))
+    {
+        return Err(format!("{CAPTURE_ENV} must use a .pdf extension"));
+    }
+    if path.to_str().is_none() {
+        return Err(format!("{CAPTURE_ENV} must be valid UTF-8"));
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{CAPTURE_ENV} must have a parent directory"))?;
+    if !parent.is_dir() {
+        return Err(format!("{CAPTURE_ENV} parent directory does not exist"));
+    }
+    if path.exists() {
+        return Err(format!("{CAPTURE_ENV} destination already exists"));
+    }
+    let metadata_path = metadata_path_for(&path);
+    if metadata_path.exists() {
+        return Err(format!("{CAPTURE_ENV} metadata destination already exists"));
+    }
+    Ok(Some(path))
+}
+
+fn metadata_path_for(pdf_path: &Path) -> PathBuf {
+    pdf_path.with_extension("pdf.json")
+}
+
+pub(crate) async fn capture_attached_webview(
+    window: &WebviewWindow,
+    pdf_path: PathBuf,
+) -> Result<PrintCaptureResult, String> {
+    let (sender, receiver) = mpsc::sync_channel(1);
+    window
+        .with_webview(move |platform_webview| {
+            let result = unsafe { capture_webview(platform_webview.inner(), &pdf_path) };
+            let _ = sender.send(result);
+        })
+        .map_err(|error| format!("could not access attached webview: {error}"))?;
+
+    tauri::async_runtime::spawn_blocking(move || {
+        receiver
+            .recv()
+            .map_err(|_| "attached webview print capture ended without a result".to_string())?
+    })
+    .await
+    .map_err(|error| format!("print capture worker failed: {error}"))?
+}
+
+unsafe fn capture_webview(
+    webview_pointer: *mut c_void,
+    pdf_path: &Path,
+) -> Result<PrintCaptureResult, String> {
+    let webview = webview_pointer
+        .cast::<WKWebView>()
+        .as_ref()
+        .ok_or_else(|| "attached WKWebView pointer was null".to_string())?;
+
+    // Copy shared state so the diagnostic preserves printer/paper/scaling without
+    // mutating the process-global print settings. The four margin writes mirror
+    // wry 0.54.4 PrintOptions::default() exactly.
+    let print_info = NSPrintInfo::sharedPrintInfo().copy();
+    print_info.setTopMargin(0.0);
+    print_info.setRightMargin(0.0);
+    print_info.setBottomMargin(0.0);
+    print_info.setLeftMargin(0.0);
+    print_info.setJobDisposition(NSPrintSaveJob);
+
+    let path_string = NSString::from_str(
+        pdf_path
+            .to_str()
+            .ok_or_else(|| "capture path must be valid UTF-8".to_string())?,
+    );
+    let output_url = NSURL::fileURLWithPath(&path_string);
+    let print_dictionary = print_info.dictionary();
+    print_dictionary.setObject_forKey(&output_url, ProtocolObject::from_ref(NSPrintJobSavingURL));
+
+    let snapshot = snapshot_print_info(&print_info);
+    let operation = webview.printOperationWithPrintInfo(&print_info);
+    operation.setCanSpawnSeparateThread(true);
+    operation.setShowsPrintPanel(false);
+    operation.setShowsProgressPanel(false);
+    let operation_succeeded = operation.runOperation();
+    if !operation_succeeded {
+        return Err("attached WKWebView print operation failed".to_string());
+    }
+    if !pdf_path.is_file() {
+        return Err("print operation completed without creating a PDF".to_string());
+    }
+
+    let pdf = inspect_pdf(pdf_path)?;
+    let metadata_path = metadata_path_for(pdf_path);
+    let result = PrintCaptureResult {
+        operation_succeeded,
+        pdf_path: pdf_path.display().to_string(),
+        metadata_path: metadata_path.display().to_string(),
+        print_info: snapshot,
+        pdf,
+    };
+    let metadata = serde_json::to_vec_pretty(&result)
+        .map_err(|error| format!("could not serialize print capture metadata: {error}"))?;
+    std::fs::write(&metadata_path, metadata)
+        .map_err(|error| format!("could not write print capture metadata: {error}"))?;
+    Ok(result)
+}
+
+fn snapshot_print_info(print_info: &NSPrintInfo) -> PrintInfoSnapshot {
+    let paper_size = print_info.paperSize();
+    let imageable = print_info.imageablePageBounds();
+    PrintInfoSnapshot {
+        paper_size: SizeSnapshot {
+            width: paper_size.width,
+            height: paper_size.height,
+        },
+        imageable_page_bounds: rect_snapshot(imageable),
+        margins: MarginsSnapshot {
+            top: print_info.topMargin(),
+            right: print_info.rightMargin(),
+            bottom: print_info.bottomMargin(),
+            left: print_info.leftMargin(),
+        },
+        scaling_factor: print_info.scalingFactor(),
+        paper_name: print_info.paperName().map(|name| name.to_string()),
+        orientation: orientation_value(print_info.orientation()),
+        horizontal_pagination: pagination_value(print_info.horizontalPagination()),
+        vertical_pagination: pagination_value(print_info.verticalPagination()),
+    }
+}
+
+fn orientation_value(value: NSPaperOrientation) -> i64 {
+    value.0 as i64
+}
+
+fn pagination_value(value: NSPrintingPaginationMode) -> i64 {
+    value.0 as i64
+}
+
+fn inspect_pdf(path: &Path) -> Result<PdfInspection, String> {
+    use std::os::unix::ffi::OsStrExt;
+
+    let filename = CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| "could not open PDF: path contains a NUL byte".to_string())?;
+    let provider = unsafe { CGDataProvider::with_filename(filename.as_ptr()) }
+        .ok_or_else(|| "could not open PDF data provider".to_string())?;
+    let document = CGPDFDocument::with_provider(Some(&provider))
+        .ok_or_else(|| "could not open PDF document".to_string())?;
+    let page_count = CGPDFDocument::number_of_pages(Some(&document));
+    if page_count == 0 {
+        return Err("could not open PDF document with at least one page".to_string());
+    }
+
+    let mut pages = Vec::with_capacity(page_count);
+    for page_number in 1..=page_count {
+        let page = CGPDFDocument::page(Some(&document), page_number)
+            .ok_or_else(|| format!("could not open PDF page {page_number}"))?;
+        let media_box = CGPDFPage::box_rect(Some(&page), CGPDFBox::MediaBox);
+        let non_white_pixel_count = count_non_white_pixels(&page)?;
+        pages.push(PdfPageInspection {
+            media_box: rect_snapshot(media_box),
+            is_visually_blank: non_white_pixel_count == 0,
+            non_white_pixel_count,
+        });
+    }
+    Ok(PdfInspection { page_count, pages })
+}
+
+fn count_non_white_pixels(page: &CGPDFPage) -> Result<usize, String> {
+    let mut pixels = vec![255_u8; RASTER_SIZE * RASTER_SIZE * 4];
+    let color_space = CGColorSpace::new_device_rgb()
+        .ok_or_else(|| "could not create PDF inspection color space".to_string())?;
+    let bitmap_info = CGImageAlphaInfo::PremultipliedLast.0 | CGImageByteOrderInfo::Order32Big.0;
+    let context = unsafe {
+        CGBitmapContextCreate(
+            pixels.as_mut_ptr().cast(),
+            RASTER_SIZE,
+            RASTER_SIZE,
+            8,
+            RASTER_SIZE * 4,
+            Some(&color_space),
+            bitmap_info,
+        )
+    }
+    .ok_or_else(|| "could not create PDF inspection bitmap".to_string())?;
+    let target = NSRect::new(
+        NSPoint::new(0.0, 0.0),
+        NSSize::new(RASTER_SIZE as f64, RASTER_SIZE as f64),
+    );
+    let transform = CGPDFPage::drawing_transform(Some(page), CGPDFBox::MediaBox, target, 0, true);
+    CGContext::concat_ctm(Some(&context), transform);
+    CGContext::draw_pdf_page(Some(&context), Some(page));
+    CGContext::flush(Some(&context));
+    drop(context);
+
+    Ok(pixels
+        .chunks_exact(4)
+        .filter(|pixel| pixel[0] < 250 || pixel[1] < 250 || pixel[2] < 250)
+        .count())
+}
+
+fn rect_snapshot(rect: NSRect) -> RectSnapshot {
+    RectSnapshot {
+        x: rect.origin.x,
+        y: rect.origin.y,
+        width: rect.size.width,
+        height: rect.size.height,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pdf_writer::{Content, Finish, Pdf, Rect, Ref};
+    use std::ffi::OsString;
+
+    fn two_page_fixture() -> Vec<u8> {
+        let mut pdf = Pdf::new();
+        let catalog = Ref::new(1);
+        let pages = Ref::new(2);
+        let first_page = Ref::new(3);
+        let first_content = Ref::new(4);
+        let second_page = Ref::new(5);
+
+        pdf.catalog(catalog).pages(pages);
+        pdf.pages(pages).kids([first_page, second_page]).count(2);
+
+        let mut page = pdf.page(first_page);
+        page.media_box(Rect::new(0.0, 0.0, 595.0, 842.0));
+        page.parent(pages);
+        page.contents(first_content);
+        page.finish();
+
+        let mut content = Content::new();
+        content.rect(100.0, 100.0, 200.0, 200.0);
+        content.fill_nonzero();
+        pdf.stream(first_content, &content.finish());
+
+        let mut page = pdf.page(second_page);
+        page.media_box(Rect::new(0.0, 0.0, 595.0, 842.0));
+        page.parent(pages);
+        page.finish();
+
+        pdf.finish()
+    }
+
+    #[test]
+    fn capture_path_is_disabled_when_environment_value_is_absent() {
+        assert_eq!(capture_path_from_value(None).unwrap(), None);
+    }
+
+    #[test]
+    fn capture_path_accepts_a_new_absolute_pdf_in_an_existing_directory() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("capture.pdf");
+
+        assert_eq!(
+            capture_path_from_value(Some(path.as_os_str().to_owned())).unwrap(),
+            Some(path)
+        );
+    }
+
+    #[test]
+    fn capture_path_rejects_relative_non_pdf_and_existing_destinations() {
+        assert!(capture_path_from_value(Some(OsString::from("capture.pdf")))
+            .unwrap_err()
+            .contains("absolute"));
+
+        let directory = tempfile::tempdir().unwrap();
+        let non_pdf = directory.path().join("capture.json");
+        assert!(capture_path_from_value(Some(non_pdf.into_os_string()))
+            .unwrap_err()
+            .contains(".pdf"));
+
+        let existing = directory.path().join("capture.pdf");
+        std::fs::write(&existing, b"do not overwrite").unwrap();
+        assert!(capture_path_from_value(Some(existing.into_os_string()))
+            .unwrap_err()
+            .contains("already exists"));
+    }
+
+    #[test]
+    fn inspect_pdf_reports_page_geometry_and_visual_blankness() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("fixture.pdf");
+        std::fs::write(&path, two_page_fixture()).unwrap();
+
+        let inspection = inspect_pdf(&path).unwrap();
+
+        assert_eq!(inspection.page_count, 2);
+        assert_eq!(inspection.pages.len(), 2);
+        assert_eq!(inspection.pages[0].media_box.width, 595.0);
+        assert_eq!(inspection.pages[0].media_box.height, 842.0);
+        assert!(!inspection.pages[0].is_visually_blank);
+        assert!(inspection.pages[1].is_visually_blank);
+    }
+
+    #[test]
+    fn inspect_pdf_rejects_invalid_input() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("missing.pdf");
+
+        assert!(inspect_pdf(&path).unwrap_err().contains("open PDF"));
+    }
+}

--- a/apps/desktop/src-tauri/src/macos_print_geometry_probe.rs
+++ b/apps/desktop/src-tauri/src/macos_print_geometry_probe.rs
@@ -1,0 +1,438 @@
+use crate::macos_print_capture::{
+    rect_snapshot, snapshot_print_info, PrintInfoSnapshot, RectSnapshot,
+};
+use crate::print_probe::{write_probe_stage, PrintProbeInput, ProbeStage};
+use block2::RcBlock;
+use objc2::MainThreadMarker;
+use objc2_app_kit::{NSApplication, NSModalPanelRunLoopMode, NSPrintInfo};
+use objc2_foundation::{NSCopying, NSRange, NSRunLoop, NSRunLoopCommonModes, NSThread, NSTimer};
+use objc2_web_kit::WKWebView;
+use serde::Serialize;
+use std::ffi::c_void;
+use std::fs::OpenOptions;
+use std::path::{Path, PathBuf};
+use std::ptr::NonNull;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+use tauri::WebviewWindow;
+
+const AUTO_ABORT_DELAY: Duration = Duration::from_secs(2);
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+const MAX_PAGE_RECTS: usize = 32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CoordinatorDecision {
+    Poll,
+    AbortModal,
+}
+
+#[derive(Debug, Default)]
+struct AutoAbortState {
+    aborted: bool,
+    timer_fired: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FinitePageRange {
+    location: usize,
+    length: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PageRectSnapshot {
+    page: usize,
+    rect: RectSnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PrintViewSnapshot {
+    frame: RectSnapshot,
+    bounds: RectSnapshot,
+    visible_rect: RectSnapshot,
+    is_flipped: bool,
+    pages: Vec<PageRectSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GeometryObservation {
+    schema_version: u32,
+    mode: &'static str,
+    run_operation_succeeded: bool,
+    operation_outcome: &'static str,
+    range: FinitePageRange,
+    probe_input: PrintProbeInput,
+    print_info: PrintInfoSnapshot,
+    print_view: PrintViewSnapshot,
+}
+
+fn geometry_observation(
+    operation_succeeded: bool,
+    range: FinitePageRange,
+    probe_input: PrintProbeInput,
+    print_info: PrintInfoSnapshot,
+    print_view: PrintViewSnapshot,
+) -> Result<GeometryObservation, String> {
+    if operation_succeeded {
+        return Err("automatic print geometry probe unexpectedly succeeded".to_string());
+    }
+    Ok(GeometryObservation {
+        schema_version: 1,
+        mode: "attached-wkwebview-modal-auto-abort",
+        run_operation_succeeded: false,
+        operation_outcome: "auto-aborted-before-post-run-range-capture",
+        range,
+        probe_input,
+        print_info,
+        print_view,
+    })
+}
+
+fn coordinator_decision(elapsed: Duration) -> CoordinatorDecision {
+    if elapsed >= AUTO_ABORT_DELAY {
+        CoordinatorDecision::AbortModal
+    } else {
+        CoordinatorDecision::Poll
+    }
+}
+
+fn finite_page_range(range: NSRange) -> Result<FinitePageRange, String> {
+    let ns_integer_max = isize::MAX as usize;
+    if range.location == 0 || range.location >= ns_integer_max {
+        return Err("print geometry probe range location is not finite".to_string());
+    }
+    if range.length == 0 || range.length == ns_integer_max {
+        return Err("print geometry probe range length is not finite".to_string());
+    }
+    let last_page = range
+        .location
+        .checked_add(range.length - 1)
+        .ok_or_else(|| "print geometry probe range overflow".to_string())?;
+    if last_page > ns_integer_max {
+        return Err("print geometry probe last page exceeds NSIntegerMax".to_string());
+    }
+    Ok(FinitePageRange {
+        location: range.location,
+        length: range.length,
+    })
+}
+
+pub(crate) fn observe_attached_webview_geometry(
+    window: &WebviewWindow,
+    path: PathBuf,
+    input: PrintProbeInput,
+) -> Result<(), String> {
+    input.validate()?;
+    if !NSThread::isMainThread_class() {
+        return Err("print geometry probe must start on the macOS main thread".to_string());
+    }
+
+    let outcome = Arc::new(OnceLock::new());
+    let callback_outcome = Arc::clone(&outcome);
+    window
+        .with_webview(move |platform_webview| {
+            let result =
+                unsafe { observe_webview(platform_webview.inner(), path.as_path(), input) };
+            let _ = callback_outcome.set(result);
+        })
+        .map_err(|error| format!("could not access attached webview: {error}"))?;
+
+    Arc::try_unwrap(outcome)
+        .map_err(|_| "print geometry probe callback was retained".to_string())?
+        .into_inner()
+        .ok_or_else(|| "print geometry probe returned no result".to_string())?
+}
+
+unsafe fn observe_webview(
+    webview_pointer: *mut c_void,
+    path: &Path,
+    input: PrintProbeInput,
+) -> Result<(), String> {
+    let webview = webview_pointer
+        .cast::<WKWebView>()
+        .as_ref()
+        .ok_or_else(|| "attached WKWebView pointer was null".to_string())?;
+
+    let print_info = NSPrintInfo::sharedPrintInfo().copy();
+    print_info.setTopMargin(0.0);
+    print_info.setRightMargin(0.0);
+    print_info.setBottomMargin(0.0);
+    print_info.setLeftMargin(0.0);
+    let operation = webview.printOperationWithPrintInfo(&print_info);
+    operation.setCanSpawnSeparateThread(true);
+    operation.setShowsPrintPanel(true);
+    operation.setShowsProgressPanel(false);
+
+    let (timer, auto_abort_state) = install_auto_abort_timer(path.to_path_buf());
+    let operation_succeeded = operation.runOperation();
+    timer.invalidate();
+    let state = auto_abort_state
+        .lock()
+        .map_err(|_| "print geometry probe auto-abort state was poisoned".to_string())?;
+    if !state.timer_fired {
+        return Err("print geometry probe timer did not fire".to_string());
+    }
+    if !state.aborted {
+        return Err("print operation ended before automatic modal abort".to_string());
+    }
+    drop(state);
+
+    let operation_range = finite_page_range(operation.pageRange())?;
+    write_probe_stage(path, ProbeStage::FiniteRangeCaptured)?;
+    if operation_range.length > MAX_PAGE_RECTS {
+        return Err(format!(
+            "print geometry probe range exceeds {MAX_PAGE_RECTS} pages"
+        ));
+    }
+
+    let view = operation
+        .view()
+        .ok_or_else(|| "print geometry probe operation had no retained view".to_string())?;
+    let pages = (operation_range.location..operation_range.location + operation_range.length)
+        .map(|page| PageRectSnapshot {
+            page,
+            rect: rect_snapshot(view.rectForPage(page as isize)),
+        })
+        .collect();
+    let observation = geometry_observation(
+        operation_succeeded,
+        operation_range,
+        input,
+        snapshot_print_info(&operation.printInfo()),
+        PrintViewSnapshot {
+            frame: rect_snapshot(view.frame()),
+            bounds: rect_snapshot(view.bounds()),
+            visible_rect: rect_snapshot(view.visibleRect()),
+            is_flipped: view.isFlipped(),
+            pages,
+        },
+    )?;
+    write_observation(path, &observation)
+}
+
+fn install_auto_abort_timer(
+    observation_path: PathBuf,
+) -> (objc2::rc::Retained<NSTimer>, Arc<Mutex<AutoAbortState>>) {
+    let state = Arc::new(Mutex::new(AutoAbortState::default()));
+    let timer_state = Arc::clone(&state);
+    let started_at = Instant::now();
+    let block = RcBlock::new(move |timer_pointer: NonNull<NSTimer>| {
+        let first_tick = {
+            let mut state = timer_state
+                .lock()
+                .expect("print geometry probe auto-abort state was poisoned");
+            let first_tick = !state.timer_fired;
+            state.timer_fired = true;
+            first_tick
+        };
+        if first_tick {
+            let _ = write_probe_stage(&observation_path, ProbeStage::TimerFired);
+        }
+        let decision = coordinator_decision(started_at.elapsed());
+        if matches!(decision, CoordinatorDecision::Poll) {
+            return;
+        }
+
+        {
+            let mut state = timer_state
+                .lock()
+                .expect("print geometry probe auto-abort state was poisoned");
+            state.aborted = true;
+        }
+        let _ = write_probe_stage(&observation_path, ProbeStage::ModalAborted);
+        unsafe { timer_pointer.as_ref() }.invalidate();
+        let marker =
+            MainThreadMarker::new().expect("modal print timer did not execute on the main thread");
+        NSApplication::sharedApplication(marker).abortModal();
+    });
+    let timer = unsafe {
+        NSTimer::timerWithTimeInterval_repeats_block(POLL_INTERVAL.as_secs_f64(), true, &block)
+    };
+    unsafe {
+        let run_loop = NSRunLoop::mainRunLoop();
+        run_loop.addTimer_forMode(&timer, NSModalPanelRunLoopMode);
+        run_loop.addTimer_forMode(&timer, NSRunLoopCommonModes);
+    }
+    (timer, state)
+}
+
+fn write_observation(path: &Path, observation: &GeometryObservation) -> Result<(), String> {
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| format!("could not create print geometry observation: {error}"))?;
+    serde_json::to_writer_pretty(file, observation)
+        .map_err(|error| format!("could not write print geometry observation: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::macos_print_capture::{MarginsSnapshot, SizeSnapshot};
+    use objc2_foundation::NSRange;
+
+    fn print_info_fixture() -> PrintInfoSnapshot {
+        PrintInfoSnapshot {
+            paper_size: SizeSnapshot {
+                width: 595.0,
+                height: 842.0,
+            },
+            imageable_page_bounds: RectSnapshot {
+                x: 12.0,
+                y: 12.0,
+                width: 571.0,
+                height: 818.0,
+            },
+            margins: MarginsSnapshot {
+                top: 0.0,
+                right: 0.0,
+                bottom: 0.0,
+                left: 0.0,
+            },
+            scaling_factor: 1.0,
+            paper_name: Some("iso-a4".to_string()),
+            orientation: 0,
+            horizontal_pagination: 2,
+            vertical_pagination: 0,
+        }
+    }
+
+    fn input_fixture() -> PrintProbeInput {
+        PrintProbeInput {
+            engine_page_count: 1,
+            dom_page_count: 1,
+            page_width_mm: 210.0,
+            page_height_mm: 297.0,
+            final_break_is_auto: true,
+        }
+    }
+
+    fn view_fixture() -> PrintViewSnapshot {
+        PrintViewSnapshot {
+            frame: RectSnapshot {
+                x: 0.0,
+                y: 0.0,
+                width: 595.0,
+                height: 843.0,
+            },
+            bounds: RectSnapshot {
+                x: 0.0,
+                y: 0.0,
+                width: 595.0,
+                height: 843.0,
+            },
+            visible_rect: RectSnapshot {
+                x: 0.0,
+                y: 0.0,
+                width: 595.0,
+                height: 843.0,
+            },
+            is_flipped: true,
+            pages: vec![
+                PageRectSnapshot {
+                    page: 1,
+                    rect: RectSnapshot {
+                        x: 0.0,
+                        y: 0.0,
+                        width: 595.0,
+                        height: 842.0,
+                    },
+                },
+                PageRectSnapshot {
+                    page: 2,
+                    rect: RectSnapshot {
+                        x: 0.0,
+                        y: 842.0,
+                        width: 595.0,
+                        height: 1.0,
+                    },
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn modal_is_aborted_only_after_the_pagination_settle_delay() {
+        assert_eq!(
+            coordinator_decision(AUTO_ABORT_DELAY - Duration::from_millis(1)),
+            CoordinatorDecision::Poll
+        );
+        assert_eq!(
+            coordinator_decision(AUTO_ABORT_DELAY),
+            CoordinatorDecision::AbortModal
+        );
+    }
+
+    #[test]
+    fn unknown_or_zero_page_ranges_are_rejected_after_modal_abort() {
+        assert!(finite_page_range(NSRange::new(1, isize::MAX as usize)).is_err());
+        assert!(finite_page_range(NSRange::new(0, 2)).is_err());
+        assert!(finite_page_range(NSRange::new(isize::MAX as usize, 2)).is_err());
+    }
+
+    #[test]
+    fn observation_rejects_success_and_serializes_only_sanitized_geometry() {
+        assert!(geometry_observation(
+            true,
+            FinitePageRange {
+                location: 1,
+                length: 2,
+            },
+            input_fixture(),
+            print_info_fixture(),
+            view_fixture(),
+        )
+        .unwrap_err()
+        .contains("succeeded"));
+
+        let observation = geometry_observation(
+            false,
+            FinitePageRange {
+                location: 1,
+                length: 2,
+            },
+            input_fixture(),
+            print_info_fixture(),
+            view_fixture(),
+        )
+        .unwrap();
+        let json = serde_json::to_value(observation).unwrap();
+        let mut keys = json
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec![
+                "mode",
+                "operationOutcome",
+                "printInfo",
+                "printView",
+                "probeInput",
+                "range",
+                "runOperationSucceeded",
+                "schemaVersion",
+            ]
+        );
+        assert_eq!(json["printView"]["pages"][0]["page"], 1);
+        assert_eq!(json["printView"]["pages"][1]["rect"]["height"], 1.0);
+        let encoded = serde_json::to_string(&json).unwrap();
+        for forbidden in [
+            "documentPath",
+            "fileName",
+            "svg",
+            "printer",
+            "pdfPath",
+            "private-sentinel",
+        ] {
+            assert!(!encoded.contains(forbidden));
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/print_probe.rs
+++ b/apps/desktop/src-tauri/src/print_probe.rs
@@ -1,0 +1,259 @@
+use serde::{Deserialize, Serialize};
+#[cfg(any(test, all(target_os = "macos", debug_assertions)))]
+use std::ffi::OsString;
+#[cfg(any(test, all(target_os = "macos", debug_assertions)))]
+use std::fs::OpenOptions;
+#[cfg(any(test, all(target_os = "macos", debug_assertions)))]
+use std::path::{Path, PathBuf};
+
+#[cfg(any(test, all(target_os = "macos", debug_assertions)))]
+const GEOMETRY_PROBE_ENV: &str = "HOP_PRINT_GEOMETRY_PROBE_PATH";
+#[cfg(any(test, all(target_os = "macos", debug_assertions)))]
+const MAX_PROBE_PAGES: u32 = 32;
+
+#[cfg(any(test, all(target_os = "macos", debug_assertions)))]
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum ProbeStage {
+    ConfigurationChecked,
+    NativePrintEntered,
+    TimerFired,
+    ModalAborted,
+    FiniteRangeCaptured,
+}
+
+#[cfg(any(test, all(target_os = "macos", debug_assertions)))]
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProbeStatus {
+    schema_version: u32,
+    stage: ProbeStage,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PrintProbeInput {
+    pub engine_page_count: u32,
+    pub dom_page_count: u32,
+    pub page_width_mm: f64,
+    pub page_height_mm: f64,
+    pub final_break_is_auto: bool,
+}
+
+impl PrintProbeInput {
+    #[cfg(any(test, all(target_os = "macos", debug_assertions)))]
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        if self.engine_page_count == 0 || self.engine_page_count > MAX_PROBE_PAGES {
+            return Err(format!(
+                "print geometry probe engine page count must be between 1 and {MAX_PROBE_PAGES}"
+            ));
+        }
+        if self.dom_page_count != self.engine_page_count {
+            return Err(
+                "print geometry probe DOM page count must match engine page count".to_string(),
+            );
+        }
+        if !self.page_width_mm.is_finite() || self.page_width_mm <= 0.0 {
+            return Err("print geometry probe page width must be positive and finite".to_string());
+        }
+        if !self.page_height_mm.is_finite() || self.page_height_mm <= 0.0 {
+            return Err("print geometry probe page height must be positive and finite".to_string());
+        }
+        if !self.final_break_is_auto {
+            return Err("print geometry probe requires an automatic final page break".to_string());
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn geometry_probe_configured() -> Result<bool, String> {
+    #[cfg(all(target_os = "macos", debug_assertions))]
+    {
+        let Some(path) = configured_geometry_probe_path()? else {
+            return Ok(false);
+        };
+        write_probe_stage(&path, ProbeStage::ConfigurationChecked)?;
+        Ok(true)
+    }
+    #[cfg(not(all(target_os = "macos", debug_assertions)))]
+    {
+        Ok(false)
+    }
+}
+
+#[cfg(any(test, all(target_os = "macos", debug_assertions)))]
+pub(crate) fn write_probe_stage(observation_path: &Path, stage: ProbeStage) -> Result<(), String> {
+    let status_path = probe_status_path(observation_path);
+    let file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(status_path)
+        .map_err(|error| format!("could not create print geometry probe status: {error}"))?;
+    serde_json::to_writer(
+        file,
+        &ProbeStatus {
+            schema_version: 1,
+            stage,
+        },
+    )
+    .map_err(|error| format!("could not write print geometry probe status: {error}"))
+}
+
+#[cfg(any(test, all(target_os = "macos", debug_assertions)))]
+fn probe_status_path(observation_path: &Path) -> PathBuf {
+    observation_path.with_extension("status.json")
+}
+
+#[cfg(all(target_os = "macos", debug_assertions))]
+pub(crate) fn configured_geometry_probe_path() -> Result<Option<PathBuf>, String> {
+    geometry_probe_path_from_value(std::env::var_os(GEOMETRY_PROBE_ENV))
+}
+
+#[cfg(any(test, all(target_os = "macos", debug_assertions)))]
+fn geometry_probe_path_from_value(value: Option<OsString>) -> Result<Option<PathBuf>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let path = PathBuf::from(value);
+    validate_destination(&path)?;
+    Ok(Some(path))
+}
+
+#[cfg(any(test, all(target_os = "macos", debug_assertions)))]
+fn validate_destination(path: &Path) -> Result<(), String> {
+    if !path.is_absolute() {
+        return Err(format!("{GEOMETRY_PROBE_ENV} must be an absolute path"));
+    }
+    if path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_none_or(|extension| !extension.eq_ignore_ascii_case("json"))
+    {
+        return Err(format!("{GEOMETRY_PROBE_ENV} must use a .json extension"));
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{GEOMETRY_PROBE_ENV} must have a parent directory"))?;
+    if !parent.is_dir() {
+        return Err(format!(
+            "{GEOMETRY_PROBE_ENV} parent directory does not exist"
+        ));
+    }
+    if path.exists() {
+        return Err(format!("{GEOMETRY_PROBE_ENV} destination already exists"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    fn valid_input() -> PrintProbeInput {
+        PrintProbeInput {
+            engine_page_count: 1,
+            dom_page_count: 1,
+            page_width_mm: 210.0,
+            page_height_mm: 297.0,
+            final_break_is_auto: true,
+        }
+    }
+
+    #[test]
+    fn geometry_probe_path_requires_new_absolute_json_destination() {
+        let directory = tempfile::tempdir().unwrap();
+        let destination = directory.path().join("observation.json");
+        assert_eq!(
+            geometry_probe_path_from_value(Some(destination.clone().into_os_string())).unwrap(),
+            Some(destination.clone())
+        );
+        assert!(geometry_probe_path_from_value(Some(OsString::from("relative.json"))).is_err());
+        assert!(geometry_probe_path_from_value(Some(
+            directory.path().join("observation.txt").into_os_string()
+        ))
+        .is_err());
+        assert!(geometry_probe_path_from_value(Some(
+            directory
+                .path()
+                .join("missing")
+                .join("observation.json")
+                .into_os_string()
+        ))
+        .is_err());
+        std::fs::write(&destination, b"existing").unwrap();
+        assert!(geometry_probe_path_from_value(Some(destination.into_os_string())).is_err());
+    }
+
+    #[test]
+    fn probe_input_accepts_one_matching_finite_page() {
+        assert_eq!(valid_input().validate(), Ok(()));
+    }
+
+    #[test]
+    fn probe_input_rejects_zero_non_finite_or_mismatched_counts() {
+        assert!(PrintProbeInput {
+            engine_page_count: 0,
+            ..valid_input()
+        }
+        .validate()
+        .is_err());
+        assert!(PrintProbeInput {
+            dom_page_count: 2,
+            ..valid_input()
+        }
+        .validate()
+        .is_err());
+        assert!(PrintProbeInput {
+            page_height_mm: f64::NAN,
+            ..valid_input()
+        }
+        .validate()
+        .is_err());
+        assert!(PrintProbeInput {
+            page_width_mm: 0.0,
+            ..valid_input()
+        }
+        .validate()
+        .is_err());
+        assert!(PrintProbeInput {
+            final_break_is_auto: false,
+            ..valid_input()
+        }
+        .validate()
+        .is_err());
+    }
+
+    #[test]
+    fn probe_stage_writes_only_a_sanitized_replaceable_sidecar() {
+        let directory = tempfile::tempdir().unwrap();
+        let observation = directory.path().join("observation.json");
+
+        write_probe_stage(&observation, ProbeStage::ConfigurationChecked).unwrap();
+        let status = probe_status_path(&observation);
+        assert_eq!(status, directory.path().join("observation.status.json"));
+        let first: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&status).unwrap()).unwrap();
+        assert_eq!(
+            first,
+            serde_json::json!({
+                "schemaVersion": 1,
+                "stage": "configuration-checked",
+            })
+        );
+
+        write_probe_stage(&observation, ProbeStage::NativePrintEntered).unwrap();
+        let second = std::fs::read_to_string(status).unwrap();
+        assert!(second.contains("native-print-entered"));
+        for forbidden in [
+            "documentPath",
+            "fileName",
+            "svg",
+            "printer",
+            "private-sentinel",
+        ] {
+            assert!(!second.contains(forbidden));
+        }
+    }
+}

--- a/apps/studio-host/hop-overrides.ts
+++ b/apps/studio-host/hop-overrides.ts
@@ -10,6 +10,7 @@ const overrideIds = [
   'core/desktop-chrome',
   'core/desktop-events',
   'core/platform',
+  'core/print-probe-trigger',
   'core/tauri-bridge',
   'command/shortcut-map',
   'command/commands/edit',

--- a/apps/studio-host/src/command/commands/file.test.ts
+++ b/apps/studio-host/src/command/commands/file.test.ts
@@ -80,10 +80,20 @@ describe('file command desktop overrides', () => {
   });
 
   it('uses desktop print integration when available', async () => {
+    const probeInput = {
+      enginePageCount: 1,
+      domPageCount: 1,
+      pageWidthMm: 210,
+      pageHeightMm: 297,
+      finalBreakIsAuto: true,
+    };
+    const printCurrentWebview = vi.fn().mockResolvedValue(undefined);
     const wasm = desktopBridge({
-      printCurrentWebview: vi.fn().mockResolvedValue(undefined),
+      printCurrentWebview,
     });
-    openPrintDialog.mockResolvedValue(undefined);
+    openPrintDialog.mockImplementation(async (_document, options) => {
+      await options.print(probeInput);
+    });
 
     await command('file:print').execute(services({ wasm }) as never);
 
@@ -91,6 +101,7 @@ describe('file command desktop overrides', () => {
       wasm,
       expect.objectContaining({ print: expect.any(Function) }),
     );
+    expect(printCurrentWebview).toHaveBeenCalledWith(probeInput);
   });
 
   it('keeps PDF export desktop-only', async () => {

--- a/apps/studio-host/src/command/commands/file.ts
+++ b/apps/studio-host/src/command/commands/file.ts
@@ -103,7 +103,7 @@ const desktopCommands = new Map<string, CommandDef>([
           if (statusEl) statusEl.textContent = message;
           emitStatus(services, message);
         },
-        print: desktop ? () => desktop.printCurrentWebview() : undefined,
+        print: desktop ? (probeInput) => desktop.printCurrentWebview(probeInput) : undefined,
       });
       if (statusEl) statusEl.textContent = previousStatus;
     } catch (error) {

--- a/apps/studio-host/src/core/print-probe-trigger.test.ts
+++ b/apps/studio-host/src/core/print-probe-trigger.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createPrintProbeTrigger } from './print-probe-trigger';
+
+describe('createPrintProbeTrigger', () => {
+  it('does nothing when the bridge has no probe capability', async () => {
+    const dispatch = vi.fn(() => true);
+    const trigger = createPrintProbeTrigger();
+
+    expect(await trigger({}, dispatch)).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when native probe mode is disabled', async () => {
+    const dispatch = vi.fn(() => true);
+    const trigger = createPrintProbeTrigger();
+
+    expect(await trigger({ printGeometryProbeConfigured: async () => false }, dispatch)).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('dispatches print exactly once when native probe mode is enabled', async () => {
+    const configured = vi.fn(async () => true);
+    const dispatch = vi.fn(() => true);
+    const trigger = createPrintProbeTrigger();
+    const bridge = { printGeometryProbeConfigured: configured };
+
+    expect(await trigger(bridge, dispatch)).toBe(true);
+    expect(await trigger(bridge, dispatch)).toBe(false);
+    expect(configured).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith('file:print');
+  });
+});

--- a/apps/studio-host/src/core/print-probe-trigger.ts
+++ b/apps/studio-host/src/core/print-probe-trigger.ts
@@ -1,0 +1,19 @@
+interface ProbeBridge {
+  printGeometryProbeConfigured?(): Promise<boolean>;
+}
+
+export function createPrintProbeTrigger(): (
+  bridge: unknown,
+  dispatch: (commandId: string) => boolean,
+) => Promise<boolean> {
+  let dispatched = false;
+
+  return async (bridge, dispatch) => {
+    if (dispatched) return false;
+    const candidate = bridge as ProbeBridge;
+    if (!candidate.printGeometryProbeConfigured) return false;
+    if (!await candidate.printGeometryProbeConfigured()) return false;
+    dispatched = dispatch('file:print');
+    return dispatched;
+  };
+}

--- a/apps/studio-host/src/core/tauri-bridge.test.ts
+++ b/apps/studio-host/src/core/tauri-bridge.test.ts
@@ -64,6 +64,25 @@ describe('TauriBridge', () => {
     removeMock.mockResolvedValue(undefined);
   });
 
+  it('forwards sanitized print probe inputs and queries probe configuration', async () => {
+    const bridge = new TauriBridge();
+    const probeInput = {
+      enginePageCount: 1,
+      domPageCount: 1,
+      pageWidthMm: 210,
+      pageHeightMm: 297,
+      finalBreakIsAuto: true,
+    };
+    invokeMock.mockResolvedValueOnce(undefined).mockResolvedValueOnce(true);
+
+    await bridge.printCurrentWebview(probeInput);
+    const configured = await bridge.printGeometryProbeConfigured();
+
+    expect(invokeMock).toHaveBeenNthCalledWith(1, 'print_webview', { probeInput });
+    expect(invokeMock).toHaveBeenNthCalledWith(2, 'print_geometry_probe_configured', {});
+    expect(configured).toBe(true);
+  });
+
   it('opens a native document by path, mirrors bytes into wasm, and updates title state', async () => {
     const bridge = new TauriBridge();
     fsOpenMock.mockResolvedValue(readHandle([10, 20, 30]));

--- a/apps/studio-host/src/core/tauri-bridge.ts
+++ b/apps/studio-host/src/core/tauri-bridge.ts
@@ -2,6 +2,7 @@ import { WasmBridge } from '@/core/wasm-bridge';
 import type { DocumentInfo } from '@/core/types';
 import { remove, stat } from '@tauri-apps/plugin-fs';
 import { finiteFileSize, readFileInChunks, writeFileInChunks } from './chunked-fs';
+import type { PrintProbeInput } from '@/ui/print-dialog';
 
 type DocumentFormat = 'hwp' | 'hwpx';
 
@@ -78,7 +79,8 @@ export interface DesktopBridgeApi {
   saveDocumentFromCommand(): Promise<DesktopSaveResult | null>;
   saveDocumentAsFromCommand(): Promise<DesktopSaveResult | null>;
   exportPdfFromCommand(): Promise<string | null>;
-  printCurrentWebview(): Promise<void>;
+  printGeometryProbeConfigured(): Promise<boolean>;
+  printCurrentWebview(probeInput: PrintProbeInput): Promise<void>;
   destroyCurrentWindow(): Promise<void>;
   cancelAppQuit(): Promise<void>;
   revealInFolder(): Promise<void>;
@@ -206,8 +208,12 @@ export class TauriBridge extends WasmBridge implements DesktopBridgeApi {
     }
   }
 
-  async printCurrentWebview(): Promise<void> {
-    await this.invoke<void>('print_webview');
+  async printGeometryProbeConfigured(): Promise<boolean> {
+    return this.invoke<boolean>('print_geometry_probe_configured');
+  }
+
+  async printCurrentWebview(probeInput: PrintProbeInput): Promise<void> {
+    await this.invoke<void>('print_webview', { probeInput });
   }
 
   async destroyCurrentWindow(): Promise<void> {

--- a/apps/studio-host/src/main.ts
+++ b/apps/studio-host/src/main.ts
@@ -37,6 +37,7 @@ import { enhanceCustomSelects } from '@/ui/custom-select';
 import { UpdateNotice, type UpdateNoticeActions } from '@/ui/update-notice';
 import { HomeScreen } from '@/ui/home-screen';
 import type { DesktopBridgeApi } from '@/core/tauri-bridge';
+import { createPrintProbeTrigger } from '@/core/print-probe-trigger';
 
 const wasm = createBridge();
 const eventBus = new EventBus();
@@ -95,6 +96,7 @@ const commandServices: CommandServices = {
 };
 
 const dispatcher = new CommandDispatcher(registry, commandServices, eventBus);
+const triggerPrintProbe = createPrintProbeTrigger();
 
 // 모든 내장 커맨드 등록
 registry.registerAll(fileCommands);
@@ -599,6 +601,7 @@ async function initializeDocument(
     } else {
       documentState.markClean('document-initialized');
     }
+    await triggerPrintProbe(wasm, (commandId) => dispatcher.dispatch(commandId));
   } catch (error) {
     console.error('[initDoc] 오류:', error);
     if (window.innerWidth < 768) alert(`초기화 오류: ${error}`);

--- a/apps/studio-host/src/ui/print-dialog.test.ts
+++ b/apps/studio-host/src/ui/print-dialog.test.ts
@@ -181,6 +181,33 @@ describe('openPrintDialog', () => {
     expect(doc.renderPageSvg).toHaveBeenCalledWith(2);
   });
 
+  it('isolates print layout from editor viewport constraints', async () => {
+    const doc = {
+      fileName: 'a4-one-page.hwp',
+      pageCount: 1,
+      getPageInfo: vi.fn(() => pageInfo({ width: 793.7, height: 1122.5 })),
+      renderPageSvg: vi.fn(() => '<svg></svg>'),
+    };
+
+    await openPrintDialog(doc, { print: printMock });
+
+    const printStyle = fakeDocument.head.children.find((child) => child.id === 'hop-print-style');
+    expect(printStyle).toBeDefined();
+
+    const css = printStyle!.textContent ?? '';
+    expect(css).toContain('width: auto !important;');
+    expect(css).toContain('height: auto !important;');
+    expect(css).toContain('min-width: 0 !important;');
+    expect(css).toContain('min-height: 0 !important;');
+    expect(css).toContain('overflow: visible !important;');
+    expect(css).toContain('@page { size: 210mm 297mm; margin: 0; }');
+    expect(css).toContain(`
+    #hop-print-root .hop-print-page:last-child {
+      break-after: auto;
+      page-break-after: auto;
+    }`);
+  });
+
   it('rejects malformed SVG gracefully', async () => {
     (globalThis as Record<string, unknown>).DOMParser = makeFakeDOMParser(true);
 

--- a/apps/studio-host/src/ui/print-dialog.test.ts
+++ b/apps/studio-host/src/ui/print-dialog.test.ts
@@ -181,33 +181,6 @@ describe('openPrintDialog', () => {
     expect(doc.renderPageSvg).toHaveBeenCalledWith(2);
   });
 
-  it('isolates print layout from editor viewport constraints', async () => {
-    const doc = {
-      fileName: 'a4-one-page.hwp',
-      pageCount: 1,
-      getPageInfo: vi.fn(() => pageInfo({ width: 793.7, height: 1122.5 })),
-      renderPageSvg: vi.fn(() => '<svg></svg>'),
-    };
-
-    await openPrintDialog(doc, { print: printMock });
-
-    const printStyle = fakeDocument.head.children.find((child) => child.id === 'hop-print-style');
-    expect(printStyle).toBeDefined();
-
-    const css = printStyle!.textContent ?? '';
-    expect(css).toContain('width: auto !important;');
-    expect(css).toContain('height: auto !important;');
-    expect(css).toContain('min-width: 0 !important;');
-    expect(css).toContain('min-height: 0 !important;');
-    expect(css).toContain('overflow: visible !important;');
-    expect(css).toContain('@page { size: 210mm 297mm; margin: 0; }');
-    expect(css).toContain(`
-    #hop-print-root .hop-print-page:last-child {
-      break-after: auto;
-      page-break-after: auto;
-    }`);
-  });
-
   it('rejects malformed SVG gracefully', async () => {
     (globalThis as Record<string, unknown>).DOMParser = makeFakeDOMParser(true);
 

--- a/apps/studio-host/src/ui/print-dialog.test.ts
+++ b/apps/studio-host/src/ui/print-dialog.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PageInfo } from '@/core/types';
-import { isSafePrintSvgReference, openPrintDialog } from './print-dialog';
+import {
+  isSafePrintSvgReference,
+  openPrintDialog,
+  type PrintProbeInput,
+} from './print-dialog';
 
 class FakeElement {
   id = '';
@@ -179,6 +183,70 @@ describe('openPrintDialog', () => {
     expect(doc.renderPageSvg).toHaveBeenCalledWith(0);
     expect(doc.renderPageSvg).toHaveBeenCalledWith(1);
     expect(doc.renderPageSvg).toHaveBeenCalledWith(2);
+  });
+
+  it('passes only sanitized print layout inputs to desktop printing', async () => {
+    const print = vi.fn<(input: PrintProbeInput) => void>();
+    const doc = {
+      fileName: 'private-name-must-not-be-forwarded.hwp',
+      pageCount: 1,
+      getPageInfo: vi.fn(() => pageInfo({ width: 793.7, height: 1122.5 })),
+      renderPageSvg: vi.fn(() => '<svg><text>must-not-be-forwarded</text></svg>'),
+    };
+
+    await openPrintDialog(doc, { print });
+
+    expect(print).toHaveBeenCalledWith({
+      enginePageCount: 1,
+      domPageCount: 1,
+      pageWidthMm: 210,
+      pageHeightMm: 297,
+      finalBreakIsAuto: true,
+    });
+    expect(JSON.stringify(print.mock.calls)).not.toContain('private-name');
+    expect(JSON.stringify(print.mock.calls)).not.toContain('must-not-be-forwarded');
+  });
+
+  it('continues printing when requestAnimationFrame is suspended for an occluded window', async () => {
+    let fallback: (() => void) | undefined;
+    const win = (globalThis as Record<string, unknown>).window as {
+      setTimeout: ReturnType<typeof vi.fn>;
+    };
+    win.setTimeout = vi.fn((callback: () => void) => {
+      fallback = callback;
+      return 17;
+    });
+    (globalThis as Record<string, unknown>).requestAnimationFrame = vi.fn(() => 23);
+    const doc = {
+      fileName: 'test.hwp',
+      pageCount: 1,
+      getPageInfo: vi.fn(() => pageInfo()),
+      renderPageSvg: vi.fn(() => '<svg></svg>'),
+    };
+
+    const pending = openPrintDialog(doc, { print: printMock });
+    await Promise.resolve();
+
+    expect(printMock).not.toHaveBeenCalled();
+    expect(fallback).toEqual(expect.any(Function));
+    fallback?.();
+    await pending;
+    expect(printMock).toHaveBeenCalledOnce();
+  });
+
+  it('leaves a sub-millimeter vertical guard inside the physical print page', async () => {
+    const doc = {
+      fileName: 'test.hwp',
+      pageCount: 1,
+      getPageInfo: vi.fn(() => pageInfo({ width: 793.7, height: 1122.5 })),
+      renderPageSvg: vi.fn(() => '<svg></svg>'),
+    };
+
+    await openPrintDialog(doc, { print: printMock });
+
+    const printStyle = fakeDocument.head.children.find((child) => child.id === 'hop-print-style');
+    expect(printStyle?.textContent).toContain('@page { size: 210mm 297mm; margin: 0; }');
+    expect(printStyle?.textContent).toContain('height: calc(297mm - 0.1mm);');
   });
 
   it('rejects malformed SVG gracefully', async () => {

--- a/apps/studio-host/src/ui/print-dialog.ts
+++ b/apps/studio-host/src/ui/print-dialog.ts
@@ -7,13 +7,23 @@ interface PrintableDocument {
   renderPageSvg(pageNum: number): string;
 }
 
+export interface PrintProbeInput {
+  enginePageCount: number;
+  domPageCount: number;
+  pageWidthMm: number;
+  pageHeightMm: number;
+  finalBreakIsAuto: boolean;
+}
+
 interface PrintDialogOptions {
   onStatus?(message: string): void;
-  print?(): void | Promise<void>;
+  print?(probeInput: PrintProbeInput): void | Promise<void>;
 }
 
 const PRINT_ROOT_ID = 'hop-print-root';
 const PRINT_STYLE_ID = 'hop-print-style';
+const PRINT_FRAME_FALLBACK_MS = 250;
+const PRINT_PAGE_HEIGHT_GUARD_MM = 0.1;
 
 export async function openPrintDialog(
   document: PrintableDocument,
@@ -54,7 +64,15 @@ export async function openPrintDialog(
   window.addEventListener('afterprint', cleanup, { once: true });
 
   try {
-    await (options.print?.() ?? window.print());
+    const probeInput: PrintProbeInput = {
+      enginePageCount: pageCount,
+      domPageCount: root.children.length,
+      pageWidthMm: widthMm,
+      pageHeightMm: heightMm,
+      finalBreakIsAuto: true,
+    };
+    if (options.print) await options.print(probeInput);
+    else window.print();
     if (!cleaned) cleanupTimer = window.setTimeout(cleanup, 5 * 60 * 1000);
   } catch (error) {
     window.removeEventListener('afterprint', cleanup);
@@ -99,7 +117,7 @@ function renderPrintDocumentShell(payload: {
     }
     #${PRINT_ROOT_ID} .hop-print-page {
       width: ${payload.widthMm}mm;
-      height: ${payload.heightMm}mm;
+      height: calc(${payload.heightMm}mm - ${PRINT_PAGE_HEIGHT_GUARD_MM}mm);
       margin: 0 !important;
       padding: 0 !important;
       overflow: hidden;
@@ -187,7 +205,17 @@ function removePrintDocument(): void {
 }
 
 function nextFrame(): Promise<void> {
-  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(fallbackTimer);
+      resolve();
+    };
+    const fallbackTimer = window.setTimeout(finish, PRINT_FRAME_FALLBACK_MS);
+    requestAnimationFrame(finish);
+  });
 }
 
 function nextTask(): Promise<void> {

--- a/apps/studio-host/src/ui/print-dialog.ts
+++ b/apps/studio-host/src/ui/print-dialog.ts
@@ -83,13 +83,8 @@ function renderPrintDocumentShell(payload: {
   @media print {
     html,
     body {
-      width: auto !important;
-      height: auto !important;
-      min-width: 0 !important;
-      min-height: 0 !important;
       margin: 0 !important;
       padding: 0 !important;
-      overflow: visible !important;
       background: #fff !important;
     }
     body > :not(#${PRINT_ROOT_ID}) {

--- a/apps/studio-host/src/ui/print-dialog.ts
+++ b/apps/studio-host/src/ui/print-dialog.ts
@@ -83,8 +83,13 @@ function renderPrintDocumentShell(payload: {
   @media print {
     html,
     body {
+      width: auto !important;
+      height: auto !important;
+      min-width: 0 !important;
+      min-height: 0 !important;
       margin: 0 !important;
       padding: 0 !important;
+      overflow: visible !important;
       background: #fff !important;
     }
     body > :not(#${PRINT_ROOT_ID}) {

--- a/docs/superpowers/plans/2026-07-16-macos-print-automatic-pagination-probe.md
+++ b/docs/superpowers/plans/2026-07-16-macos-print-automatic-pagination-probe.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Build a macOS-debug-only probe that automatically prepares the real HOP print DOM, opens the authentic modal preview, aborts it after pagination becomes finite, and records sanitized frontend/native geometry without user input or print output.
+**Goal:** Build a macOS-debug-only probe that automatically prepares the real HOP print DOM, opens the authentic modal preview, aborts it after a bounded settle delay, and records the post-return finite range plus sanitized frontend/native geometry without user input or print output.
 
 **Architecture:** The studio host passes a small numeric `PrintProbeInput` through the existing print callback and automatically dispatches print once when a native configuration command reports probe mode. Rust owns environment validation, modal coordination, AppKit access, page-range validation, native view/page-rect snapshots, and create-new JSON output. Normal release, non-macOS, web, and debug-without-probe printing remain unchanged.
 
@@ -84,7 +84,7 @@ pub(crate) fn observe_attached_webview_geometry(
 ) -> Result<(), String>;
 ```
 
-- [ ] **Step 1: Write frontend RED tests for the exact probe input and forwarding contract**
+- [x] **Step 1: Write frontend RED tests for the exact probe input and forwarding contract**
 
 Add a print-dialog test that executes the supplied callback and requires exactly one engine page, one `.hop-print-page`, `210 × 297` mm, and final break auto:
 
@@ -121,7 +121,7 @@ expect(invokeMock).toHaveBeenCalledWith('print_geometry_probe_configured', undef
 
 Create `print-probe-trigger.test.ts` with three cases: absent capability does nothing, configured false does nothing, configured true dispatches `file:print` exactly once across repeated document initializations.
 
-- [ ] **Step 2: Run the frontend RED tests and verify contract failures**
+- [x] **Step 2: Run the frontend RED tests and verify contract failures**
 
 Run:
 
@@ -136,7 +136,7 @@ pnpm --filter @golbin/hop-studio-host exec vitest run \
 
 Expected: exit `1`; failures are only missing `PrintProbeInput` callback forwarding, missing bridge method/arguments, and missing one-shot trigger module/behavior. Fix syntax or fixture errors until the failures are behavioral.
 
-- [ ] **Step 3: Implement the minimal frontend contract and one-shot trigger**
+- [x] **Step 3: Implement the minimal frontend contract and one-shot trigger**
 
 In `print-dialog.ts`, export `PrintProbeInput`, change `PrintDialogOptions.print` to accept it, and replace the existing fallback expression with an explicit branch:
 
@@ -201,11 +201,11 @@ const triggerPrintProbe = createPrintProbeTrigger();
 await triggerPrintProbe(wasm, (commandId) => dispatcher.dispatch(commandId));
 ```
 
-- [ ] **Step 4: Run the frontend focused tests and verify GREEN**
+- [x] **Step 4: Run the frontend focused tests and verify GREEN**
 
 Run the Step 2 command again. Expected: all selected test files pass with no new warnings.
 
-- [ ] **Step 5: Write Rust RED tests for path/input/range/view schema and coordinator outcomes**
+- [x] **Step 5: Write Rust RED tests for path/input/range/view schema and coordinator outcomes**
 
 Create `print_probe.rs` tests that require:
 
@@ -248,23 +248,21 @@ Create `macos_print_geometry_probe.rs` tests around pure functions that require:
 
 ```rust
 #[test]
-fn finite_range_becomes_abort_and_capture() {
-    assert_eq!(coordinator_decision(Some(NSRange::new(1, 2)), false), Decision::AbortAndCapture);
+fn modal_is_aborted_only_after_the_pagination_settle_delay() {
+    assert_eq!(coordinator_decision(AUTO_ABORT_DELAY - Duration::from_millis(1)), Decision::Poll);
+    assert_eq!(coordinator_decision(AUTO_ABORT_DELAY), Decision::AbortModal);
 }
 
 #[test]
-fn unknown_range_keeps_polling_until_timeout_then_aborts_with_error() {
-    assert_eq!(
-        coordinator_decision(Some(NSRange::new(1, isize::MAX as usize)), false),
-        Decision::Poll,
-    );
-    assert_eq!(coordinator_decision(None, true), Decision::AbortTimeout);
+fn unknown_or_zero_page_ranges_are_rejected_after_modal_abort() {
+    assert!(finite_page_range(NSRange::new(1, isize::MAX as usize)).is_err());
+    assert!(finite_page_range(NSRange::new(0, 2)).is_err());
 }
 ```
 
 The observation serialization test must construct two distinct `RectSnapshot` values, serialize the typed observation with `serde_json::to_value`, assert the two exact rectangles and strict top-level keys, then recursively assert that the resulting JSON contains none of `documentPath`, `fileName`, `svg`, `printer`, `pdfPath`, or an arbitrary sentinel document string.
 
-- [ ] **Step 6: Run Rust RED and verify only missing probe APIs fail**
+- [x] **Step 6: Run Rust RED and verify only missing probe APIs fail**
 
 Run:
 
@@ -274,7 +272,7 @@ cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --lib print_probe -
 
 Expected: exit `101`; failures are unresolved probe modules/functions/types or unmet assertions, not Cargo feature, syntax, or fixture errors.
 
-- [ ] **Step 7: Implement the Rust contracts and native auto-abort coordinator**
+- [x] **Step 7: Implement the Rust contracts and native auto-abort coordinator**
 
 Add macOS dependencies/features without changing versions:
 
@@ -289,8 +287,8 @@ In `macos_print_geometry_probe.rs`:
 
 1. Require the main thread and use `window.with_webview` plus `Arc<OnceLock<Result<(), String>>>`, matching the reviewed modal observer.
 2. Copy shared `NSPrintInfo`, set only the four margins to zero, create `printOperationWithPrintInfo`, enable the print panel, disable progress, and retain the view.
-3. Start a background coordinator before `runOperation()`. Every 50 ms for at most 15 seconds it calls `AppHandle::run_on_main_thread`. The main-thread closure reads `NSPrintOperation::currentOperation`, converts `pageRange` through the tested finite-range helper, and calls `NSApplication::sharedApplication(marker).abortModal()` only for a finite range. Timeout schedules the same abort call and records a timeout error.
-4. Join the coordinator after `runOperation()` returns. Reject `true`, timeout, missing finite range, missing view, or more than 32 pages.
+3. Register a repeating `NSTimer` in `NSModalPanelRunLoopMode` and `NSRunLoopCommonModes` before `runOperation()`. After a two-second settle delay, invalidate it and call `NSApplication::sharedApplication(marker).abortModal()`.
+4. After `runOperation()` returns, reject `true`, a timer that never fired, an operation that ended before automatic abort, a missing/unknown post-return range, a missing view, or more than 32 pages.
 5. Snapshot `view.frame()`, `view.bounds()`, `view.visibleRect()`, `view.isFlipped()`, the finite operation range, every `view.rectForPage(page)`, and the effective print info.
 6. Write only the strict serde structure with create-new semantics.
 
@@ -315,7 +313,7 @@ window
 
 Register `print_geometry_probe_configured` in `lib.rs`; release/non-macOS `print_webview` accepts and ignores `_probe_input` before calling the unchanged `window.print()` expression.
 
-- [ ] **Step 8: Run Rust focused and full verification**
+- [x] **Step 8: Run Rust focused and full verification**
 
 Run:
 
@@ -330,7 +328,7 @@ git diff --check
 
 Expected: all commands exit `0`; the repository's `clippy:desktop` script already runs `cargo clippy -- -D warnings`.
 
-- [ ] **Step 9: Run full frontend verification and build the debug app**
+- [x] **Step 9: Run full frontend verification and build the debug app**
 
 Run:
 
@@ -343,14 +341,15 @@ pnpm --filter hop-desktop tauri build --debug --bundles app
 
 Expected: tests and builds exit `0`; existing Vite chunk/dynamic-import warnings may remain but no new warning is accepted.
 
-- [ ] **Step 10: Run the automated native probe and preserve only sanitized evidence**
+- [x] **Step 10: Run the automated native probe and preserve only sanitized evidence**
 
 Record the private file's size, mtime, and SHA-256 without printing its content. Create a fresh temp directory, then launch:
 
 ```bash
-env HOP_PRINT_GEOMETRY_PROBE_PATH="$probe_dir/observation.json" \
-  apps/desktop/src-tauri/target/debug/bundle/macos/HOP.app/Contents/MacOS/hop-desktop \
-  '/Users/gameduo/Downloads/승선신고서.hwp'
+open -n -W \
+  --env HOP_PRINT_GEOMETRY_PROBE_PATH="$probe_dir/observation.json" \
+  -a apps/desktop/src-tauri/target/debug/bundle/macos/HOP.app \
+  '<private-hwp-path>'
 ```
 
 Wait conditionally for the JSON file with a 30-second upper bound. The app must automatically dispatch print, briefly show and abort the panel, and write JSON without clicks. Terminate only this launched debug process after the file appears.
@@ -359,14 +358,14 @@ Expected evidence:
 
 - frontend engine and DOM page counts are `1`;
 - native modal range is finite and matches the authentic `1 + 2` baseline;
-- two page rectangles plus view frame/bounds/visibleRect are present;
+- two page entries plus view frame/bounds/visibleRect are present; post-abort `rectForPage` sentinels are not used for causal inference;
 - operation outcome is auto-aborted, never successful;
 - no PDF or printer job exists;
 - private file size, mtime, and SHA-256 are unchanged.
 
 Delete the temporary JSON after transcribing numeric geometry into `.superpowers/sdd/automatic-geometry-probe-evidence.md`.
 
-- [ ] **Step 11: Review the evidence before any fix**
+- [x] **Step 11: Review the evidence before any fix**
 
 Classify the first divergence:
 
@@ -385,3 +384,9 @@ git status --short
 ```
 
 Expected: no forbidden native/output/content API usage. Do not commit implementation yet; request independent review of code and sanitized evidence first.
+
+- [x] **Step 12: Prove and fix the vertical rounding overflow with TDD**
+
+Record the baseline native range and print-view frame, then run one controlled experiment that leaves `@page` unchanged and reduces only the printable page content height by `0.1mm`. If the native range changes from two pages to one and the print-view frame changes from approximately two A4 sheets to one, classify the cause as WebKit physical-unit/integer-frame rounding overflow.
+
+Add a failing studio test that requires the physical `@page` to remain `210mm × 297mm` while `.hop-print-page` uses `calc(297mm - 0.1mm)`. Implement the named `0.1mm` guard, rerun the studio test, rebuild the app, and rerun the automatic native probe. Preserve only sanitized before/after numbers in `.superpowers/sdd/automatic-geometry-probe-evidence.md`.

--- a/docs/superpowers/plans/2026-07-16-macos-print-automatic-pagination-probe.md
+++ b/docs/superpowers/plans/2026-07-16-macos-print-automatic-pagination-probe.md
@@ -1,0 +1,387 @@
+# macOS Print Automatic Pagination Probe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a macOS-debug-only probe that automatically prepares the real HOP print DOM, opens the authentic modal preview, aborts it after pagination becomes finite, and records sanitized frontend/native geometry without user input or print output.
+
+**Architecture:** The studio host passes a small numeric `PrintProbeInput` through the existing print callback and automatically dispatches print once when a native configuration command reports probe mode. Rust owns environment validation, modal coordination, AppKit access, page-range validation, native view/page-rect snapshots, and create-new JSON output. Normal release, non-macOS, web, and debug-without-probe printing remain unchanged.
+
+**Tech Stack:** TypeScript, Vitest, Tauri 2 commands, Rust, objc2 0.6/AppKit 0.3.2/WebKit 0.3.2, serde JSON, pnpm.
+
+## Global Constraints
+
+- Use `pnpm` only.
+- Keep `third_party/rhwp` read-only.
+- Preserve normal macOS, Windows, Linux, web, release, and debug-without-probe behavior.
+- Never copy, log, serialize, or commit the private document, its path, text, SVG, or contents.
+- Never create a PDF, configure a save/preview disposition, or send a printer job.
+- The authentic print panel may appear briefly but must be aborted programmatically; `runOperation() == true` is always an error.
+- Probe destinations must be new absolute `.json` files whose parent already exists.
+- Do not commit probe implementation until automated native evidence is useful and independent review approves it.
+
+## File structure
+
+- Create `apps/desktop/src-tauri/src/print_probe.rs`: cross-platform input contract, macOS-debug environment/configuration query, validation, and unit tests.
+- Create `apps/desktop/src-tauri/src/macos_print_geometry_probe.rs`: macOS-debug AppKit/WebKit operation, auto-abort coordinator, view/page snapshots, JSON output, and unit tests.
+- Create `apps/studio-host/src/core/print-probe-trigger.ts`: one-shot opt-in automatic dispatcher with no Tauri imports.
+- Create `apps/studio-host/src/core/print-probe-trigger.test.ts`: pure trigger tests.
+- Modify `apps/studio-host/src/ui/print-dialog.ts`: construct and pass sanitized `PrintProbeInput` after print pages exist.
+- Modify `apps/studio-host/src/ui/print-dialog.test.ts`: verify exact sanitized input.
+- Modify `apps/studio-host/src/command/commands/file.ts`: forward input to the desktop bridge.
+- Modify `apps/studio-host/src/command/commands/file.test.ts`: execute the supplied callback and verify forwarding.
+- Modify `apps/studio-host/src/core/tauri-bridge.ts`: add configuration query and typed print invocation.
+- Modify `apps/studio-host/src/core/tauri-bridge.test.ts`: verify command names and argument shapes.
+- Modify `apps/studio-host/src/main.ts`: run the one-shot trigger only after successful document initialization.
+- Modify `apps/desktop/src-tauri/src/commands.rs`: expose configuration query and route opt-in geometry probes before existing modal/normal paths.
+- Modify `apps/desktop/src-tauri/src/lib.rs`: register modules and the configuration command.
+- Modify `apps/desktop/src-tauri/Cargo.toml`: enable the minimal `objc2`, `NSApplication`, and `NSView` APIs required by the coordinator and snapshots.
+
+---
+
+### Task 1: Automatic authentic modal pagination probe
+
+**Interfaces:**
+
+- Produces frontend `PrintProbeInput`:
+
+```ts
+export interface PrintProbeInput {
+  enginePageCount: number;
+  domPageCount: number;
+  pageWidthMm: number;
+  pageHeightMm: number;
+  finalBreakIsAuto: boolean;
+}
+```
+
+- Produces bridge methods:
+
+```ts
+printGeometryProbeConfigured(): Promise<boolean>;
+printCurrentWebview(probeInput: PrintProbeInput): Promise<void>;
+```
+
+- Produces Rust commands:
+
+```rust
+#[tauri::command]
+pub fn print_geometry_probe_configured() -> Result<bool, String>;
+
+#[tauri::command]
+pub fn print_webview(
+    window: WebviewWindow,
+    probe_input: Option<PrintProbeInput>,
+) -> Result<(), String>;
+```
+
+- Produces native entry point:
+
+```rust
+pub(crate) fn observe_attached_webview_geometry(
+    window: &WebviewWindow,
+    path: PathBuf,
+    input: PrintProbeInput,
+) -> Result<(), String>;
+```
+
+- [ ] **Step 1: Write frontend RED tests for the exact probe input and forwarding contract**
+
+Add a print-dialog test that executes the supplied callback and requires exactly one engine page, one `.hop-print-page`, `210 × 297` mm, and final break auto:
+
+```ts
+it('passes only sanitized print layout inputs to desktop printing', async () => {
+  const print = vi.fn<(input: PrintProbeInput) => void>();
+  const doc = {
+    fileName: 'private-name-must-not-be-forwarded.hwp',
+    pageCount: 1,
+    getPageInfo: vi.fn(() => pageInfo({ width: 793.7, height: 1122.5 })),
+    renderPageSvg: vi.fn(() => '<svg><text>must-not-be-forwarded</text></svg>'),
+  };
+
+  await openPrintDialog(doc, { print });
+
+  expect(print).toHaveBeenCalledWith({
+    enginePageCount: 1,
+    domPageCount: 1,
+    pageWidthMm: 210,
+    pageHeightMm: 297,
+    finalBreakIsAuto: true,
+  });
+  expect(JSON.stringify(print.mock.calls)).not.toContain('private-name');
+  expect(JSON.stringify(print.mock.calls)).not.toContain('must-not-be-forwarded');
+});
+```
+
+Update the file-command test to invoke `options.print(input)` and require `desktop.printCurrentWebview(input)`. Update the bridge test to require:
+
+```ts
+expect(invokeMock).toHaveBeenCalledWith('print_webview', { probeInput });
+expect(invokeMock).toHaveBeenCalledWith('print_geometry_probe_configured', undefined);
+```
+
+Create `print-probe-trigger.test.ts` with three cases: absent capability does nothing, configured false does nothing, configured true dispatches `file:print` exactly once across repeated document initializations.
+
+- [ ] **Step 2: Run the frontend RED tests and verify contract failures**
+
+Run:
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v24.4.1/bin:$PATH"
+pnpm --filter @golbin/hop-studio-host exec vitest run \
+  src/ui/print-dialog.test.ts \
+  src/command/commands/file.test.ts \
+  src/core/tauri-bridge.test.ts \
+  src/core/print-probe-trigger.test.ts
+```
+
+Expected: exit `1`; failures are only missing `PrintProbeInput` callback forwarding, missing bridge method/arguments, and missing one-shot trigger module/behavior. Fix syntax or fixture errors until the failures are behavioral.
+
+- [ ] **Step 3: Implement the minimal frontend contract and one-shot trigger**
+
+In `print-dialog.ts`, export `PrintProbeInput`, change `PrintDialogOptions.print` to accept it, and replace the existing fallback expression with an explicit branch:
+
+```ts
+const probeInput: PrintProbeInput = {
+  enginePageCount: pageCount,
+  domPageCount: root.querySelectorAll(':scope > .hop-print-page').length,
+  pageWidthMm: widthMm,
+  pageHeightMm: heightMm,
+  finalBreakIsAuto: true,
+};
+if (options.print) await options.print(probeInput);
+else window.print();
+```
+
+In `file.ts`, forward `probeInput`:
+
+```ts
+print: desktop ? (probeInput) => desktop.printCurrentWebview(probeInput) : undefined,
+```
+
+In `tauri-bridge.ts`, import the type and implement:
+
+```ts
+async printGeometryProbeConfigured(): Promise<boolean> {
+  return this.invoke<boolean>('print_geometry_probe_configured');
+}
+
+async printCurrentWebview(probeInput: PrintProbeInput): Promise<void> {
+  await this.invoke<void>('print_webview', { probeInput });
+}
+```
+
+Create the pure one-shot trigger:
+
+```ts
+interface ProbeBridge {
+  printGeometryProbeConfigured?(): Promise<boolean>;
+}
+
+export function createPrintProbeTrigger(): (
+  bridge: unknown,
+  dispatch: (commandId: string) => boolean,
+) => Promise<boolean> {
+  let dispatched = false;
+  return async (bridge, dispatch) => {
+    if (dispatched) return false;
+    const candidate = bridge as ProbeBridge;
+    if (!candidate.printGeometryProbeConfigured) return false;
+    if (!await candidate.printGeometryProbeConfigured()) return false;
+    dispatched = dispatch('file:print');
+    return dispatched;
+  };
+}
+```
+
+Instantiate once in `main.ts` and call it at the end of successful `initializeDocument`:
+
+```ts
+const triggerPrintProbe = createPrintProbeTrigger();
+// after validation/dirty-state initialization succeeds
+await triggerPrintProbe(wasm, (commandId) => dispatcher.dispatch(commandId));
+```
+
+- [ ] **Step 4: Run the frontend focused tests and verify GREEN**
+
+Run the Step 2 command again. Expected: all selected test files pass with no new warnings.
+
+- [ ] **Step 5: Write Rust RED tests for path/input/range/view schema and coordinator outcomes**
+
+Create `print_probe.rs` tests that require:
+
+```rust
+#[test]
+fn geometry_probe_path_requires_new_absolute_json_destination() {
+    let directory = tempfile::tempdir().unwrap();
+    let destination = directory.path().join("observation.json");
+    assert_eq!(
+        geometry_probe_path_from_value(Some(destination.clone().into_os_string())).unwrap(),
+        Some(destination.clone())
+    );
+    assert!(geometry_probe_path_from_value(Some("relative.json".into())).is_err());
+    assert!(geometry_probe_path_from_value(Some(
+        directory.path().join("observation.txt").into_os_string()
+    )).is_err());
+    std::fs::write(&destination, b"existing").unwrap();
+    assert!(geometry_probe_path_from_value(Some(destination.into_os_string())).is_err());
+}
+
+#[test]
+fn probe_input_rejects_zero_non_finite_or_mismatched_counts() {
+    let valid = PrintProbeInput {
+        engine_page_count: 1,
+        dom_page_count: 1,
+        page_width_mm: 210.0,
+        page_height_mm: 297.0,
+        final_break_is_auto: true,
+    };
+    assert_eq!(valid.validate(), Ok(()));
+    assert!(PrintProbeInput { engine_page_count: 0, ..valid.clone() }.validate().is_err());
+    assert!(PrintProbeInput { dom_page_count: 2, ..valid.clone() }.validate().is_err());
+    assert!(PrintProbeInput { page_height_mm: f64::NAN, ..valid }.validate().is_err());
+}
+```
+
+The configuration test must use `#[cfg(not(all(target_os = "macos", debug_assertions)))]` and assert `geometry_probe_configured() == Ok(false)` so release/non-mac behavior is explicit without mutating the process environment in parallel tests.
+
+Create `macos_print_geometry_probe.rs` tests around pure functions that require:
+
+```rust
+#[test]
+fn finite_range_becomes_abort_and_capture() {
+    assert_eq!(coordinator_decision(Some(NSRange::new(1, 2)), false), Decision::AbortAndCapture);
+}
+
+#[test]
+fn unknown_range_keeps_polling_until_timeout_then_aborts_with_error() {
+    assert_eq!(
+        coordinator_decision(Some(NSRange::new(1, isize::MAX as usize)), false),
+        Decision::Poll,
+    );
+    assert_eq!(coordinator_decision(None, true), Decision::AbortTimeout);
+}
+```
+
+The observation serialization test must construct two distinct `RectSnapshot` values, serialize the typed observation with `serde_json::to_value`, assert the two exact rectangles and strict top-level keys, then recursively assert that the resulting JSON contains none of `documentPath`, `fileName`, `svg`, `printer`, `pdfPath`, or an arbitrary sentinel document string.
+
+- [ ] **Step 6: Run Rust RED and verify only missing probe APIs fail**
+
+Run:
+
+```bash
+cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --lib print_probe -- --nocapture
+```
+
+Expected: exit `101`; failures are unresolved probe modules/functions/types or unmet assertions, not Cargo feature, syntax, or fixture errors.
+
+- [ ] **Step 7: Implement the Rust contracts and native auto-abort coordinator**
+
+Add macOS dependencies/features without changing versions:
+
+```toml
+objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSApplication", "NSDocumentController", "NSPrintInfo", "NSPrintOperation", "NSPrinter", "NSView"] }
+```
+
+In `print_probe.rs`, define the serde input, validate positive counts, equal engine/DOM counts, finite positive millimetres, and the absolute new `.json` environment path `HOP_PRINT_GEOMETRY_PROBE_PATH`. Return `false` from the configuration query outside macOS debug.
+
+In `macos_print_geometry_probe.rs`:
+
+1. Require the main thread and use `window.with_webview` plus `Arc<OnceLock<Result<(), String>>>`, matching the reviewed modal observer.
+2. Copy shared `NSPrintInfo`, set only the four margins to zero, create `printOperationWithPrintInfo`, enable the print panel, disable progress, and retain the view.
+3. Start a background coordinator before `runOperation()`. Every 50 ms for at most 15 seconds it calls `AppHandle::run_on_main_thread`. The main-thread closure reads `NSPrintOperation::currentOperation`, converts `pageRange` through the tested finite-range helper, and calls `NSApplication::sharedApplication(marker).abortModal()` only for a finite range. Timeout schedules the same abort call and records a timeout error.
+4. Join the coordinator after `runOperation()` returns. Reject `true`, timeout, missing finite range, missing view, or more than 32 pages.
+5. Snapshot `view.frame()`, `view.bounds()`, `view.visibleRect()`, `view.isFlipped()`, the finite operation range, every `view.rectForPage(page)`, and the effective print info.
+6. Write only the strict serde structure with create-new semantics.
+
+Do not call `setJobDisposition`, `setJobSavingURL`, PDF/CG APIs, `printOperationWithView`, or any printer getter.
+
+Wire commands in this order:
+
+```rust
+if let Some(path) = crate::print_probe::configured_geometry_probe_path()? {
+    let input = probe_input.ok_or_else(|| "print geometry probe requires sanitized input".to_string())?;
+    crate::macos_print_geometry_probe::observe_attached_webview_geometry(&window, path, input)?;
+    return Ok(());
+}
+if let Some(path) = crate::macos_print_capture::configured_observation_path()? {
+    crate::macos_print_capture::observe_attached_webview(&window, path)?;
+    return Ok(());
+}
+window
+    .print()
+    .map_err(|error| format!("인쇄 대화상자를 열 수 없습니다: {error}"))
+```
+
+Register `print_geometry_probe_configured` in `lib.rs`; release/non-macOS `print_webview` accepts and ignores `_probe_input` before calling the unchanged `window.print()` expression.
+
+- [ ] **Step 8: Run Rust focused and full verification**
+
+Run:
+
+```bash
+cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --lib print_probe -- --nocapture
+pnpm run test:desktop
+pnpm run clippy:desktop
+cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --release
+cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --check
+git diff --check
+```
+
+Expected: all commands exit `0`; the repository's `clippy:desktop` script already runs `cargo clippy -- -D warnings`.
+
+- [ ] **Step 9: Run full frontend verification and build the debug app**
+
+Run:
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v24.4.1/bin:$PATH"
+pnpm run test:studio
+pnpm run build:studio
+pnpm --filter hop-desktop tauri build --debug --bundles app
+```
+
+Expected: tests and builds exit `0`; existing Vite chunk/dynamic-import warnings may remain but no new warning is accepted.
+
+- [ ] **Step 10: Run the automated native probe and preserve only sanitized evidence**
+
+Record the private file's size, mtime, and SHA-256 without printing its content. Create a fresh temp directory, then launch:
+
+```bash
+env HOP_PRINT_GEOMETRY_PROBE_PATH="$probe_dir/observation.json" \
+  apps/desktop/src-tauri/target/debug/bundle/macos/HOP.app/Contents/MacOS/hop-desktop \
+  '/Users/gameduo/Downloads/승선신고서.hwp'
+```
+
+Wait conditionally for the JSON file with a 30-second upper bound. The app must automatically dispatch print, briefly show and abort the panel, and write JSON without clicks. Terminate only this launched debug process after the file appears.
+
+Expected evidence:
+
+- frontend engine and DOM page counts are `1`;
+- native modal range is finite and matches the authentic `1 + 2` baseline;
+- two page rectangles plus view frame/bounds/visibleRect are present;
+- operation outcome is auto-aborted, never successful;
+- no PDF or printer job exists;
+- private file size, mtime, and SHA-256 are unchanged.
+
+Delete the temporary JSON after transcribing numeric geometry into `.superpowers/sdd/automatic-geometry-probe-evidence.md`.
+
+- [ ] **Step 11: Review the evidence before any fix**
+
+Classify the first divergence:
+
+- input `1`, native view/range `2`, and a tiny second rect: WebKit/AppKit rounding or layout overflow candidate;
+- input `1`, native view height near two full sheets and two full rects: attached editor document contributes a full extra fragment;
+- auto-abort range differs from the human-cancel `2`: reject and remove the probe;
+- any successful operation/output/privacy field: stop, remove artifacts, and treat as a critical failure.
+
+Run source checks:
+
+```bash
+rg -n "NSPrintSaveJob|NSPrintPreviewJob|setJobSavingURL|pdf|printer\(|documentPath|fileName|renderPageSvg" \
+  apps/desktop/src-tauri/src/{print_probe,macos_print_geometry_probe}.rs
+git diff --check
+git status --short
+```
+
+Expected: no forbidden native/output/content API usage. Do not commit implementation yet; request independent review of code and sanitized evidence first.

--- a/docs/superpowers/specs/2026-07-16-macos-print-automatic-pagination-probe-design.md
+++ b/docs/superpowers/specs/2026-07-16-macos-print-automatic-pagination-probe-design.md
@@ -1,0 +1,102 @@
+# macOS Print Automatic Pagination Probe Design
+
+## Background
+
+HOP renders each HWP page as SVG and temporarily appends a print-only DOM to the editor's attached `WKWebView`. A private one-page document consistently appears as two pages in the real macOS print preview, with the second page blank. The attached-WebView modal observer has reproduced a finite native range of pages 1–2 twice with unchanged settings.
+
+Three controlled candidates have been disproven by the real preview and native range:
+
+- resetting editor viewport constraints during print;
+- removing the one-page document's forced trailing break declarations;
+- changing copied `NSPrintInfo.verticalPagination` from `Automatic` to `Clip`.
+
+The upstream rhwp studio prints from a dedicated document window, while HOP prints from the editor document. The remaining unknown is the boundary at which one engine page becomes two WebKit/AppKit print pages.
+
+## Problem
+
+The current observer exposes only the final `NSPrintOperation.pageRange` and `NSPrintInfo`. It does not expose the print DOM geometry or the `NSView` owned by the operation. As a result, it proves the symptom but cannot distinguish among:
+
+- an oversized or residual box in the attached editor document;
+- a WebKit print-layout fragment or rounding overflow;
+- an AppKit print-view geometry/page-rect mismatch.
+
+The session's trusted Computer Use runtime lacks its required `node_repl`, so native modal UI automation is unavailable. Requiring repeated human Cmd+P/Cancel checks is not acceptable for this diagnostic loop.
+
+## Goal
+
+Create a debug-only, opt-in, fully automatic pagination probe that opens the private document, prepares the normal HOP print DOM, records sanitized DOM and native print-view geometry without showing a print panel or creating output, writes one JSON artifact, and exits or becomes safe to terminate.
+
+Success means the artifact identifies the first boundary where the expected one page becomes two pages, with enough geometry to form one precise root-cause hypothesis.
+
+## Non-goals
+
+- Do not implement or claim a product fix.
+- Do not send a printer job, generate a PDF, or open the print panel.
+- Do not serialize document text, SVG, file path, printer name, or document contents.
+- Do not modify `third_party/rhwp`.
+- Do not alter release, non-macOS, or normal debug printing behavior.
+
+## Constraints
+
+- The private HWP remains in place and is never copied, logged, or committed.
+- The probe is compiled only for macOS debug builds and activated only by a new absolute `.json` destination environment variable.
+- The existing modal observer and normal `window.print()` path remain unchanged when the new variable is absent.
+- The probe must use the attached HOP `WKWebView` and the same copied shared `NSPrintInfo`, four zero margins, and `printOperationWithPrintInfo` factory as wry/HOP.
+- The native probe must not call `runOperation()`; it may only inspect the operation's retained print view.
+- JSON files use create-new semantics and contain only numeric/boolean/enumerated diagnostic data.
+
+## Considered approaches
+
+### 1. Automatic attached-WebView geometry probe — selected
+
+After the normal print DOM is built, the frontend sends a sanitized DOM snapshot together with the existing print command. In probe mode, Rust creates the attached-WebView print operation, reads its retained `NSView`, invokes `knowsPageRange`, and records `frame`, `bounds`, `visibleRect`, and `rectForPage` for the finite range. No operation is run.
+
+This isolates the DOM → WebKit print view → AppKit page rect boundaries while preserving the exact document and attached-WebView architecture.
+
+### 2. Dedicated print window comparison — deferred
+
+Moving HOP immediately to the upstream dedicated-window model could eliminate editor-layout contamination, but it would be a product architecture change before the cause is proven. It is appropriate only as a later controlled comparison or confirmed fix.
+
+### 3. Standalone WebKit harness — rejected for primary evidence
+
+The earlier standalone/save-job probes did not reproduce the attached application's finite pagination and one path grew an unbounded PDF. A standalone harness cannot establish the attached HOP WebView's cause.
+
+## Architecture and data flow
+
+1. `openPrintDialog` builds the existing root and SVG pages.
+2. A pure TypeScript helper captures only layout geometry and safe computed-style values:
+   - engine page count and print-root child count;
+   - viewport dimensions;
+   - `html`, `body`, print root, and each print-page bounding rectangles;
+   - scroll/client/offset dimensions;
+   - display, position, overflow, box sizing, width, height, min/max sizes, margins, padding, and break properties.
+3. The desktop bridge passes this snapshot to `print_webview` only as an optional argument. Web and normal desktop behavior remain compatible.
+4. When `HOP_PRINT_GEOMETRY_PROBE_PATH` is configured, Rust creates the normal attached-WebView print operation but does not run it.
+5. Rust obtains `operation.view()`, snapshots native view class-independent geometry, calls `knowsPageRange`, validates a finite range, and records `rectForPage` for each page with a strict small upper bound.
+6. Rust combines the frontend and native snapshots with the existing `NSPrintInfo` snapshot and writes a new JSON file with create-new semantics.
+7. The automatic debug trigger dispatches `file:print` once after the document initialization is complete. The trigger is enabled only when the native probe reports it is configured.
+8. The harness waits for the JSON file, terminates the debug app, and compares expected engine/DOM page count with native range and page rectangles.
+
+## Error handling and privacy
+
+- Reject relative paths, non-JSON extensions, missing parents, and existing destinations before probing.
+- Reject missing print view, unknown/zero/overflow page ranges, ranges above a small diagnostic limit, and non-finite frontend geometry.
+- Do not include filenames, source paths, document strings, SVG, URLs, printer identifiers, or arbitrary computed-style text.
+- Serialize style properties as booleans or allow-listed enum/numeric strings only.
+- A failed probe returns an explicit error and does not fall back to normal printing, preventing accidental modal or printer activity.
+
+## Verification plan
+
+- TypeScript RED/GREEN tests for sanitized DOM snapshot construction and opt-in automatic dispatch.
+- Rust RED/GREEN tests for environment validation, finite range/page-rect conversion, strict field schema, and no-run operation assembly boundaries.
+- Focused studio tests, full studio tests, desktop tests, clippy with warnings denied, release check, formatting, and debug app build.
+- Automated integration run against the private one-page document, with JSON existence and schema checks and private file hash/mtime verification.
+- Source review proving no `runOperation`, save/preview job disposition, PDF URL, printer name, document path, or content serialization exists in the probe path.
+
+## Rollback and recovery
+
+The probe is diagnostic and must remain uncommitted until its native output is useful and independently reviewed. If `knowsPageRange` is unknown or inconsistent with the authentic modal range, remove the probe changes and preserve only the report. Any temporary JSON is deleted after transcribing sanitized evidence. The existing committed modal observer remains available as the authentic comparison seam.
+
+## Approval
+
+The user approved this automatic, no-human-print-panel diagnostic direction on 2026-07-16.

--- a/docs/superpowers/specs/2026-07-16-macos-print-automatic-pagination-probe-design.md
+++ b/docs/superpowers/specs/2026-07-16-macos-print-automatic-pagination-probe-design.md
@@ -24,7 +24,7 @@ The session's trusted Computer Use runtime lacks its required `node_repl`, so na
 
 ## Goal
 
-Create a debug-only, opt-in, fully automatic pagination probe that opens the private document, prepares the normal HOP print DOM, opens the authentic modal preview, automatically cancels it as soon as pagination becomes finite, records sanitized print inputs and native print-view geometry, writes one JSON artifact, and exits or becomes safe to terminate.
+Create a debug-only, opt-in, fully automatic pagination probe that opens the private document, prepares the normal HOP print DOM, opens the authentic modal preview, cancels it after a bounded pagination-settle delay, then records the post-return finite range and sanitized print-view geometry without user input.
 
 Success means the artifact identifies the first boundary where the expected one page becomes two pages, with enough geometry to form one precise root-cause hypothesis.
 
@@ -42,16 +42,16 @@ Success means the artifact identifies the first boundary where the expected one 
 - The probe is compiled only for macOS debug builds and activated only by a new absolute `.json` destination environment variable.
 - The existing modal observer and normal `window.print()` path remain unchanged when the new variable is absent.
 - The probe must use the attached HOP `WKWebView` and the same copied shared `NSPrintInfo`, four zero margins, and `printOperationWithPrintInfo` factory as wry/HOP.
-- The native probe must call the same modal `runOperation()` seam that produced the authentic finite range, then cancel it through AppKit as soon as the range is finite. It must never approve the operation.
+- The native probe must call the same modal `runOperation()` seam that produced the authentic finite range, cancel it through AppKit after a bounded settle delay, and read the finite range only after `runOperation()` returns. It must never approve the operation.
 - JSON files use create-new semantics and contain only numeric/boolean/enumerated diagnostic data.
 
 ## Considered approaches
 
 ### 1. Automatic authentic modal geometry probe — selected
 
-After the normal print DOM is built, the frontend sends sanitized numeric layout inputs together with the existing print command. In probe mode, Rust creates and runs the attached-WebView modal print operation. A bounded background coordinator polls `NSPrintOperation.currentOperation` only through main-thread closures. When `pageRange` becomes finite, the main-thread closure calls `NSApplication.abortModal`. Rust then records the operation view's `frame`, `bounds`, `visibleRect`, and `rectForPage` for the finite range.
+After the normal print DOM is built, the frontend sends sanitized numeric layout inputs together with the existing print command. In probe mode, Rust creates and runs the attached-WebView modal print operation. An `NSTimer` registered in both the modal and common run-loop modes waits two seconds, then calls `NSApplication.abortModal`. Rust validates the finite `pageRange` after `runOperation()` returns and records the operation view's `frame`, `bounds`, `visibleRect`, and `rectForPage` values.
 
-This preserves the exact empirical seam that matched the visible two-page preview while removing all human Cmd+P/Cancel actions. The coordinator has a strict timeout that also aborts the modal and reports failure without falling through to printing.
+This preserves the exact empirical seam that matched the visible two-page preview while removing all human Cmd+P/Cancel actions. A sanitized status sidecar distinguishes frontend configuration, native entry, timer execution, modal abort, and final range capture. No failure falls through to normal printing.
 
 ### 2. Dedicated print window comparison — deferred
 
@@ -70,8 +70,8 @@ The earlier standalone/save-job probes did not reproduce the attached applicatio
    - whether the final page uses authored `auto` break rules.
 3. The desktop bridge passes this snapshot to `print_webview` only as an optional argument. Web and normal desktop behavior remain compatible.
 4. When `HOP_PRINT_GEOMETRY_PROBE_PATH` is configured, Rust creates the normal attached-WebView print operation and starts the bounded auto-cancel coordinator before running it.
-5. The coordinator polls on the main thread until the current operation exposes a finite range, snapshots that range, and calls `NSApplication.abortModal`; timeout follows the same abort-only path and is an error.
-6. After `runOperation()` returns `false`, Rust obtains `operation.view()`, snapshots native view class-independent geometry, validates the finite range, and records `rectForPage` for each page with a strict small upper bound.
+5. A main-run-loop timer fires inside the modal loop, waits for the bounded settle delay, and calls `NSApplication.abortModal` without approving or submitting the operation.
+6. After `runOperation()` returns `false`, Rust validates the now-finite range, obtains `operation.view()`, snapshots native view class-independent geometry, and records `rectForPage` for each page with a strict small upper bound.
 7. Rust combines the frontend inputs and native snapshots with the existing `NSPrintInfo` snapshot and writes a new JSON file with create-new semantics.
 8. The automatic debug trigger dispatches `file:print` once after the document initialization is complete. The trigger is enabled only when the native probe reports it is configured.
 9. The harness waits for the JSON file, terminates the debug app, and compares expected engine/DOM page count with native range and page rectangles.
@@ -79,7 +79,7 @@ The earlier standalone/save-job probes did not reproduce the attached applicatio
 ## Error handling and privacy
 
 - Reject relative paths, non-JSON extensions, missing parents, and existing destinations before probing.
-- Reject missing print view, unknown/zero/overflow page ranges, ranges above a small diagnostic limit, timeout, an unexpectedly successful print operation, and non-finite frontend geometry.
+- Reject missing print view, unknown/zero/overflow post-return page ranges, ranges above a small diagnostic limit, a timer that did not fire, an operation that ended before automatic abort, an unexpectedly successful print operation, and non-finite frontend geometry.
 - Do not include filenames, source paths, document strings, SVG, URLs, printer identifiers, or arbitrary computed-style text.
 - Serialize style properties as booleans or allow-listed enum/numeric strings only.
 - A failed probe returns an explicit error and does not fall back to normal printing, preventing accidental modal or printer activity.
@@ -87,7 +87,7 @@ The earlier standalone/save-job probes did not reproduce the attached applicatio
 ## Verification plan
 
 - TypeScript RED/GREEN tests for sanitized print-input construction and opt-in one-shot automatic dispatch.
-- Rust RED/GREEN tests for environment validation, finite range/page-rect conversion, strict field schema, bounded coordinator outcomes, and abort-only operation assembly boundaries.
+- Rust RED/GREEN tests for environment validation, sanitized status writes, post-abort finite range/page-rect conversion, strict field schema, bounded coordinator timing, and abort-only operation assembly boundaries.
 - Focused studio tests, full studio tests, desktop tests, clippy with warnings denied, release check, formatting, and debug app build.
 - Automated integration run against the private one-page document, with JSON existence and schema checks and private file hash/mtime verification.
 - Source review proving the probe treats `runOperation() == true` as failure and contains no save/preview job disposition, PDF URL, printer name, document path, or content serialization.

--- a/docs/superpowers/specs/2026-07-16-macos-print-automatic-pagination-probe-design.md
+++ b/docs/superpowers/specs/2026-07-16-macos-print-automatic-pagination-probe-design.md
@@ -24,14 +24,14 @@ The session's trusted Computer Use runtime lacks its required `node_repl`, so na
 
 ## Goal
 
-Create a debug-only, opt-in, fully automatic pagination probe that opens the private document, prepares the normal HOP print DOM, records sanitized DOM and native print-view geometry without showing a print panel or creating output, writes one JSON artifact, and exits or becomes safe to terminate.
+Create a debug-only, opt-in, fully automatic pagination probe that opens the private document, prepares the normal HOP print DOM, opens the authentic modal preview, automatically cancels it as soon as pagination becomes finite, records sanitized print inputs and native print-view geometry, writes one JSON artifact, and exits or becomes safe to terminate.
 
 Success means the artifact identifies the first boundary where the expected one page becomes two pages, with enough geometry to form one precise root-cause hypothesis.
 
 ## Non-goals
 
 - Do not implement or claim a product fix.
-- Do not send a printer job, generate a PDF, or open the print panel.
+- Do not send a printer job or generate a PDF. The authentic print panel may appear briefly but must be cancelled programmatically without user input.
 - Do not serialize document text, SVG, file path, printer name, or document contents.
 - Do not modify `third_party/rhwp`.
 - Do not alter release, non-macOS, or normal debug printing behavior.
@@ -42,61 +42,60 @@ Success means the artifact identifies the first boundary where the expected one 
 - The probe is compiled only for macOS debug builds and activated only by a new absolute `.json` destination environment variable.
 - The existing modal observer and normal `window.print()` path remain unchanged when the new variable is absent.
 - The probe must use the attached HOP `WKWebView` and the same copied shared `NSPrintInfo`, four zero margins, and `printOperationWithPrintInfo` factory as wry/HOP.
-- The native probe must not call `runOperation()`; it may only inspect the operation's retained print view.
+- The native probe must call the same modal `runOperation()` seam that produced the authentic finite range, then cancel it through AppKit as soon as the range is finite. It must never approve the operation.
 - JSON files use create-new semantics and contain only numeric/boolean/enumerated diagnostic data.
 
 ## Considered approaches
 
-### 1. Automatic attached-WebView geometry probe — selected
+### 1. Automatic authentic modal geometry probe — selected
 
-After the normal print DOM is built, the frontend sends a sanitized DOM snapshot together with the existing print command. In probe mode, Rust creates the attached-WebView print operation, reads its retained `NSView`, invokes `knowsPageRange`, and records `frame`, `bounds`, `visibleRect`, and `rectForPage` for the finite range. No operation is run.
+After the normal print DOM is built, the frontend sends sanitized numeric layout inputs together with the existing print command. In probe mode, Rust creates and runs the attached-WebView modal print operation. A bounded background coordinator polls `NSPrintOperation.currentOperation` only through main-thread closures. When `pageRange` becomes finite, the main-thread closure calls `NSApplication.abortModal`. Rust then records the operation view's `frame`, `bounds`, `visibleRect`, and `rectForPage` for the finite range.
 
-This isolates the DOM → WebKit print view → AppKit page rect boundaries while preserving the exact document and attached-WebView architecture.
+This preserves the exact empirical seam that matched the visible two-page preview while removing all human Cmd+P/Cancel actions. The coordinator has a strict timeout that also aborts the modal and reports failure without falling through to printing.
 
 ### 2. Dedicated print window comparison — deferred
 
 Moving HOP immediately to the upstream dedicated-window model could eliminate editor-layout contamination, but it would be a product architecture change before the cause is proven. It is appropriate only as a later controlled comparison or confirmed fix.
 
-### 3. Standalone WebKit harness — rejected for primary evidence
+### 3. No-run or standalone WebKit harness — rejected for primary evidence
 
-The earlier standalone/save-job probes did not reproduce the attached application's finite pagination and one path grew an unbounded PDF. A standalone harness cannot establish the attached HOP WebView's cause.
+The earlier standalone/save-job probes did not reproduce the attached application's finite pagination and one path grew an unbounded PDF. Before `runOperation`, the print view reported `NSIntegerMax` and dummy `(0, 0, 1, 1)` rectangles. A no-run or standalone harness therefore cannot establish the attached HOP WebView's cause.
 
 ## Architecture and data flow
 
 1. `openPrintDialog` builds the existing root and SVG pages.
-2. A pure TypeScript helper captures only layout geometry and safe computed-style values:
+2. A pure TypeScript helper captures only safe numeric/authored inputs available before WebKit creates its private print clone:
    - engine page count and print-root child count;
-   - viewport dimensions;
-   - `html`, `body`, print root, and each print-page bounding rectangles;
-   - scroll/client/offset dimensions;
-   - display, position, overflow, box sizing, width, height, min/max sizes, margins, padding, and break properties.
+   - page width and height in millimetres;
+   - whether the final page uses authored `auto` break rules.
 3. The desktop bridge passes this snapshot to `print_webview` only as an optional argument. Web and normal desktop behavior remain compatible.
-4. When `HOP_PRINT_GEOMETRY_PROBE_PATH` is configured, Rust creates the normal attached-WebView print operation but does not run it.
-5. Rust obtains `operation.view()`, snapshots native view class-independent geometry, calls `knowsPageRange`, validates a finite range, and records `rectForPage` for each page with a strict small upper bound.
-6. Rust combines the frontend and native snapshots with the existing `NSPrintInfo` snapshot and writes a new JSON file with create-new semantics.
-7. The automatic debug trigger dispatches `file:print` once after the document initialization is complete. The trigger is enabled only when the native probe reports it is configured.
-8. The harness waits for the JSON file, terminates the debug app, and compares expected engine/DOM page count with native range and page rectangles.
+4. When `HOP_PRINT_GEOMETRY_PROBE_PATH` is configured, Rust creates the normal attached-WebView print operation and starts the bounded auto-cancel coordinator before running it.
+5. The coordinator polls on the main thread until the current operation exposes a finite range, snapshots that range, and calls `NSApplication.abortModal`; timeout follows the same abort-only path and is an error.
+6. After `runOperation()` returns `false`, Rust obtains `operation.view()`, snapshots native view class-independent geometry, validates the finite range, and records `rectForPage` for each page with a strict small upper bound.
+7. Rust combines the frontend inputs and native snapshots with the existing `NSPrintInfo` snapshot and writes a new JSON file with create-new semantics.
+8. The automatic debug trigger dispatches `file:print` once after the document initialization is complete. The trigger is enabled only when the native probe reports it is configured.
+9. The harness waits for the JSON file, terminates the debug app, and compares expected engine/DOM page count with native range and page rectangles.
 
 ## Error handling and privacy
 
 - Reject relative paths, non-JSON extensions, missing parents, and existing destinations before probing.
-- Reject missing print view, unknown/zero/overflow page ranges, ranges above a small diagnostic limit, and non-finite frontend geometry.
+- Reject missing print view, unknown/zero/overflow page ranges, ranges above a small diagnostic limit, timeout, an unexpectedly successful print operation, and non-finite frontend geometry.
 - Do not include filenames, source paths, document strings, SVG, URLs, printer identifiers, or arbitrary computed-style text.
 - Serialize style properties as booleans or allow-listed enum/numeric strings only.
 - A failed probe returns an explicit error and does not fall back to normal printing, preventing accidental modal or printer activity.
 
 ## Verification plan
 
-- TypeScript RED/GREEN tests for sanitized DOM snapshot construction and opt-in automatic dispatch.
-- Rust RED/GREEN tests for environment validation, finite range/page-rect conversion, strict field schema, and no-run operation assembly boundaries.
+- TypeScript RED/GREEN tests for sanitized print-input construction and opt-in one-shot automatic dispatch.
+- Rust RED/GREEN tests for environment validation, finite range/page-rect conversion, strict field schema, bounded coordinator outcomes, and abort-only operation assembly boundaries.
 - Focused studio tests, full studio tests, desktop tests, clippy with warnings denied, release check, formatting, and debug app build.
 - Automated integration run against the private one-page document, with JSON existence and schema checks and private file hash/mtime verification.
-- Source review proving no `runOperation`, save/preview job disposition, PDF URL, printer name, document path, or content serialization exists in the probe path.
+- Source review proving the probe treats `runOperation() == true` as failure and contains no save/preview job disposition, PDF URL, printer name, document path, or content serialization.
 
 ## Rollback and recovery
 
-The probe is diagnostic and must remain uncommitted until its native output is useful and independently reviewed. If `knowsPageRange` is unknown or inconsistent with the authentic modal range, remove the probe changes and preserve only the report. Any temporary JSON is deleted after transcribing sanitized evidence. The existing committed modal observer remains available as the authentic comparison seam.
+The probe is diagnostic and must remain uncommitted until its native output is useful and independently reviewed. If auto-cancel cannot produce the same finite range as the human-cancel observer, remove the probe changes and preserve only the report. Any temporary JSON is deleted after transcribing sanitized evidence. The existing committed modal observer remains available as the authentic comparison seam.
 
 ## Approval
 
-The user approved this automatic, no-human-print-panel diagnostic direction on 2026-07-16.
+The user approved this automatic, no-human-interaction diagnostic direction on 2026-07-16.


### PR DESCRIPTION
## Summary

- add an opt-in, sanitized macOS print geometry probe that compares HWP engine, print DOM, and AppKit page counts
- reproduce the failure as `1 / 1 / 2` with public portrait samples and isolate it to the WKWebView/AppKit physical-height rounding boundary
- keep the real `@page` paper size while applying a `0.1mm` height guard to the print root
- cover the print CSS and native probe path with regression tests

## Root cause

For a one-page A4 portrait document, HOP gave the print root the exact physical page height (`297mm`). WKWebView's CSS-to-device-unit conversion rounded that boundary past AppKit's printable page extent, so AppKit paginated the single DOM page into two native pages and produced a blank trailing page.

Reducing only the content root height by `0.1mm` keeps it below the rounding boundary. The paper size remains exact because `@page { size: ... }` is unchanged.

## Verification

- `pnpm test`
  - upstream tests: 12 passed
  - Studio tests: 130 passed
  - Desktop tests: 97 passed
  - Quick Look tests: 6 passed
- public `para-head-num-2.hwp` probe:
  - before: engine / DOM / AppKit = `1 / 1 / 2`
  - after: engine / DOM / AppKit = `1 / 1 / 1`
- genuine two-page fixture remains `2 / 2 / 2`
- the same public sample displays as one page in the upstream rhwp demo

Fixes #83

## Before / after

| HOP 0.3.1 | Fixed build |
|---|---|
| ![Before: two print pages with a blank second page](https://raw.githubusercontent.com/kilhyeonjun/hop/b25e87f3c1b58d75aea3aa7fb19e26956dd2af30/docs/evidence/macos-print-blank-page/before.png) | ![After: one print page](https://raw.githubusercontent.com/kilhyeonjun/hop/b25e87f3c1b58d75aea3aa7fb19e26956dd2af30/docs/evidence/macos-print-blank-page/after.png) |

The upstream rhwp demo renders and prints the same public sample as one page: [evidence](https://raw.githubusercontent.com/kilhyeonjun/hop/b25e87f3c1b58d75aea3aa7fb19e26956dd2af30/docs/evidence/macos-print-blank-page/upstream-rhwp.png).
